### PR TITLE
chore: restrict Vercel builds to main branch only

### DIFF
--- a/scripts/should-build.sh
+++ b/scripts/should-build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Vercel Ignored Build Step script.
+# Exit 1 = proceed with build. Exit 0 = skip build.
+#
+# Desired behavior:
+#   - Push to `main`          → production build  (VERCEL_ENV=production)
+#   - PR targeting `main`     → preview build     (VERCEL_ENV=preview)
+#   - Everything else         → skip
+
+if [ "$VERCEL_ENV" = "production" ]; then
+  echo "Production build — proceeding (branch: $VERCEL_GIT_COMMIT_REF)"
+  exit 1
+fi
+
+if [ "$VERCEL_ENV" = "preview" ]; then
+  echo "Preview build — proceeding (branch: $VERCEL_GIT_COMMIT_REF)"
+  exit 1
+fi
+
+echo "Skipping build (env: $VERCEL_ENV, branch: $VERCEL_GIT_COMMIT_REF)"
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,10 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "installCommand": "npm ci",
+  "ignoreCommand": "bash scripts/should-build.sh",
   "git": {
     "deploymentEnabled": {
-      "main": true,
-      "develop": true
+      "main": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes `develop` from `deploymentEnabled` in `vercel.json` so Vercel no longer auto-deploys direct pushes to `develop` or creates PR previews for PRs targeting `develop`
- Adds `ignoreCommand` pointing to `scripts/should-build.sh` as a safety net
- Script exits `1` (build) only for `VERCEL_ENV=production` (push to `main`) or `VERCEL_ENV=preview` (PR targeting `main`); exits `0` (skip) for everything else

## Test plan

- [ ] Merge this PR to `develop` — confirm no Vercel preview build is triggered for this PR
- [ ] Open a PR from `develop` → `main` — confirm a Vercel preview build is triggered
- [ ] Merge to `main` — confirm Vercel production build runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)