### PR TITLE
fix(chat): move source citations into scrollable message list

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -12,7 +12,7 @@
 import { useState, useCallback } from 'react';
 import { MessageList, type ChatMessage } from './MessageList';
 import { ChatInput } from './ChatInput';
-import { SourceCitations, type SourceCitation } from './SourceCitations';
+import { type SourceCitation } from './SourceCitations';
 import { ErrorBoundary } from './ErrorBoundary';
 
 interface ChatInterfaceProps {
@@ -151,14 +151,7 @@ function ChatInterfaceInner({ initialMessages = [] }: ChatInterfaceProps) {
       </div>
 
       {/* Messages */}
-      <MessageList messages={messages} streamingContent={streamingContent} />
-
-      {/* Sources */}
-      {sources.length > 0 && (
-        <div className="px-4 pb-2">
-          <SourceCitations sources={sources} />
-        </div>
-      )}
+      <MessageList messages={messages} streamingContent={streamingContent} sources={sources} />
 
       {/* Error display */}
       {error && (

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -9,6 +9,7 @@
 
 import { useRef, useEffect } from 'react';
 import { MessageBubble } from './MessageBubble';
+import { SourceCitations, type SourceCitation } from './SourceCitations';
 
 export interface ChatMessage {
   id: string;
@@ -19,9 +20,10 @@ export interface ChatMessage {
 interface MessageListProps {
   messages: ChatMessage[];
   streamingContent?: string;
+  sources?: SourceCitation[];
 }
 
-export function MessageList({ messages, streamingContent }: MessageListProps) {
+export function MessageList({ messages, streamingContent, sources }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to bottom when new messages arrive
@@ -61,6 +63,11 @@ export function MessageList({ messages, streamingContent }: MessageListProps) {
       ))}
       {streamingContent && (
         <MessageBubble role="assistant" content={streamingContent} isStreaming />
+      )}
+      {sources && sources.length > 0 && !streamingContent && (
+        <div className="px-0 pb-2">
+          <SourceCitations sources={sources} />
+        </div>
       )}
       <div ref={bottomRef} />
     </div>


### PR DESCRIPTION
## Summary

- Source citations were rendered as a fixed-height panel outside the scroll container, sandwiched between the message list and the input — this squished the message area and made responses hard to read on small screens
- Sources are now rendered inline inside the scrollable `MessageList`, appearing after the last assistant message once streaming completes
- The auto-scroll `bottomRef` now includes sources in the scroll target, so the view lands at the sources section after a response finishes

## Test plan

- [x] Ask a question and verify the response + sources scroll together as one unit
- [x] Verify sources only appear after streaming finishes (not mid-stream)
- [x] Verify "Clear chat" removes sources
- [x] Check on a small viewport (mobile-sized) that the full response is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)