### PR TITLE
Fix various UI/UX bugs and add category reorder + AI writing actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "@aws-sdk/client-s3": "^3.1026.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@pinecone-database/pinecone": "^7.1.0",
         "@roadlittledawn/docs-design-system-react": "^0.13.0",
@@ -26,6 +29,7 @@
         "postcss": "^8.5.8",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.8.0",
         "rehype-pretty-code": "^0.14.3",
         "rehype-unwrap-images": "^1.0.0",
@@ -1180,6 +1184,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6989,6 +7046,16 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -11749,6 +11816,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-resizable-panels": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@aws-sdk/client-s3": "^3.1026.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@pinecone-database/pinecone": "^7.1.0",
     "@roadlittledawn/docs-design-system-react": "^0.13.0",
@@ -32,6 +35,7 @@
     "postcss": "^8.5.8",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.8.0",
     "rehype-pretty-code": "^0.14.3",
     "rehype-unwrap-images": "^1.0.0",

--- a/src/app/admin/categories/page.tsx
+++ b/src/app/admin/categories/page.tsx
@@ -130,11 +130,11 @@ export default function AdminCategoriesPage() {
   }, []);
 
   const handleReorderCategories = useCallback(
-    async (categoryId: string, newOrder: number): Promise<void> => {
-      const res = await fetch(`/api/categories/${categoryId}`, {
+    async (parentId: string | null, orderedIds: string[]): Promise<void> => {
+      const res = await fetch('/api/categories/reorder', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ order: newOrder }),
+        body: JSON.stringify({ parentId, orderedIds }),
       });
       if (!res.ok) {
         const err = await res.json();

--- a/src/app/api/ai/writing-agent/route.ts
+++ b/src/app/api/ai/writing-agent/route.ts
@@ -26,6 +26,8 @@ type WritingAction =
   | 'review'
   | 'improve'
   | 'expand'
+  | 'reformat'
+  | 'custom'
   | 'suggest-title'
   | 'suggest-tags'
   | 'research'
@@ -48,6 +50,8 @@ interface WritingAgentRequest {
   frontmatter: EntryFrontmatter;
   selection?: string;
   context?: string;
+  /** Free-form user instruction for the 'custom' action and an optional add-on for 'reformat' */
+  customPrompt?: string;
 }
 
 /**
@@ -72,6 +76,8 @@ function getActionConfig(action: WritingAction): {
     case 'review':
     case 'improve':
     case 'expand':
+    case 'reformat':
+    case 'custom':
       return { defaultPersona: 'writer' };
     case 'suggest-title':
     case 'suggest-tags':
@@ -84,10 +90,24 @@ function getActionConfig(action: WritingAction): {
 /**
  * Build action-specific instructions for the prompt
  */
-function getActionInstructions(action: WritingAction, selection?: string): string {
+function getActionInstructions(
+  action: WritingAction,
+  selection?: string,
+  customPrompt?: string
+): string {
   const selectionContext = selection
     ? `\n\nThe user has selected the following text for you to focus on:\n<selection>\n${selection}\n</selection>`
     : '';
+
+  const customInstruction = customPrompt?.trim()
+    ? `\n\nAdditional instructions from the user:\n<instructions>\n${customPrompt.trim()}\n</instructions>`
+    : '';
+
+  // For actions whose output replaces the editor body, the model must emit only the
+  // raw MDX body — no commentary, no surrounding code fences.
+  const rawMdxOnly =
+    `\n\nOutput ONLY the resulting MDX body, ready to be saved directly as the entry content. ` +
+    `Do not include any explanation, preamble, or wrapping code fences.`;
 
   switch (action) {
     case 'review':
@@ -96,6 +116,22 @@ function getActionInstructions(action: WritingAction, selection?: string): strin
       return `Improve the content by enhancing clarity, fixing issues, and making it more engaging while preserving the original meaning.${selectionContext}`;
     case 'expand':
       return `Expand the content with additional details, examples, and explanations while maintaining consistency with the existing style.${selectionContext}`;
+    case 'reformat':
+      return (
+        `Reformat the entry content to make better use of the docs-design-system-react (DDS) ` +
+        `component library for improved structure, layout, and readability. Preserve all of the ` +
+        `original information and meaning — do not add new facts or remove substance. Convert ` +
+        `appropriate plain-markdown sections into suitable DDS components (callouts, tabs, ` +
+        `collapsers, tables, etc.) where they genuinely improve clarity, and leave simple content ` +
+        `as-is. ${selection ? 'Reformat only the selected text.' : 'Reformat the entire body.'}` +
+        `${selectionContext}${customInstruction}${rawMdxOnly}`
+      );
+    case 'custom':
+      return (
+        `Follow the user's instructions below to transform the entry content. ` +
+        `${selection ? 'Apply them to the selected text.' : 'Apply them to the entire body.'}` +
+        `${selectionContext}${customInstruction}${rawMdxOnly}`
+      );
     case 'suggest-title':
       return `Suggest 3-5 compelling titles for this content. Each title should be concise, descriptive, and engaging.${selectionContext}`;
     case 'suggest-tags':
@@ -122,7 +158,8 @@ function buildSystemPrompt(
   skillPrompt: string | null,
   componentDocs: string | null,
   action: WritingAction,
-  selection?: string
+  selection?: string,
+  customPrompt?: string
 ): string {
   const parts: string[] = [];
 
@@ -159,7 +196,7 @@ function buildSystemPrompt(
   }
 
   // Add action-specific instructions (Requirement 8.12 for selection context)
-  parts.push(`\n## Task\n\n${getActionInstructions(action, selection)}`);
+  parts.push(`\n## Task\n\n${getActionInstructions(action, selection, customPrompt)}`);
 
   return parts.join('\n\n');
 }
@@ -266,11 +303,20 @@ export async function POST(request: NextRequest) {
       frontmatter,
       selection,
       context: additionalContext,
+      customPrompt,
     } = body as WritingAgentRequest;
 
     // Validate required fields
     if (!action) {
       return new Response(JSON.stringify({ error: 'Action is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // The custom action is driven entirely by the user's prompt
+    if (action === 'custom' && !customPrompt?.trim()) {
+      return new Response(JSON.stringify({ error: 'A custom prompt is required' }), {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -334,7 +380,8 @@ export async function POST(request: NextRequest) {
       null, // Skill prompt would be passed from request if specified
       componentDocs,
       action,
-      selection
+      selection,
+      customPrompt
     );
 
     // Build user message

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Category reorder API route
+ * PUT /api/categories/reorder - Reorder a sibling group of categories
+ *
+ * Accepts the full ordered list of sibling IDs for a single parent and assigns
+ * each a 1-based `order` value. Renumbering the whole group (rather than nudging
+ * a single category's order up/down) avoids duplicate/negative order values and
+ * the resulting validation 500s. An order of 0 is reserved for "unordered"
+ * categories, which sort alphabetically (A–Z).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import { connectToDatabase } from '@/lib/db/connection';
+import { Category } from '@/lib/db/models/Category';
+
+interface ReorderRequest {
+  parentId: string | null;
+  orderedIds: string[];
+}
+
+interface ReorderResponse {
+  ok: true;
+}
+
+interface ErrorResponse {
+  error: string;
+  code?: string;
+}
+
+export async function PUT(
+  request: NextRequest
+): Promise<NextResponse<ReorderResponse | ErrorResponse>> {
+  try {
+    const body = (await request.json()) as ReorderRequest;
+    const { parentId, orderedIds } = body;
+
+    if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+      return NextResponse.json(
+        { error: 'orderedIds must be a non-empty array', code: 'VALIDATION_ERROR' },
+        { status: 400 }
+      );
+    }
+
+    if (orderedIds.some((id) => !mongoose.Types.ObjectId.isValid(id))) {
+      return NextResponse.json(
+        { error: 'orderedIds contains an invalid category ID', code: 'INVALID_ID' },
+        { status: 400 }
+      );
+    }
+
+    const normalizedParentId =
+      parentId === '' || parentId === null || parentId === undefined ? null : parentId;
+
+    if (normalizedParentId !== null && !mongoose.Types.ObjectId.isValid(normalizedParentId)) {
+      return NextResponse.json(
+        { error: 'Invalid parent category ID', code: 'INVALID_ID' },
+        { status: 400 }
+      );
+    }
+
+    await connectToDatabase();
+
+    // Verify every provided ID actually belongs to the given parent. This guards
+    // against renumbering categories from another branch of the tree.
+    const siblings = await Category.find({ parentId: normalizedParentId })
+      .select('_id')
+      .lean();
+    const siblingIds = new Set(siblings.map((s) => s._id.toString()));
+
+    if (orderedIds.some((id) => !siblingIds.has(id))) {
+      return NextResponse.json(
+        { error: 'orderedIds must all belong to the same parent', code: 'PARENT_MISMATCH' },
+        { status: 400 }
+      );
+    }
+
+    // Assign 1-based order values in the provided sequence.
+    await Category.bulkWrite(
+      orderedIds.map((id, index) => ({
+        updateOne: {
+          filter: { _id: new mongoose.Types.ObjectId(id) },
+          update: { $set: { order: index + 1 } },
+        },
+      }))
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error reordering categories:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -69,7 +69,7 @@ export async function GET(): Promise<NextResponse<CategoriesListResponse | Error
   try {
     await connectToDatabase();
 
-    const categories = await Category.find().sort({ order: 1 }).lean();
+    const categories = await Category.find().sort({ order: 1, name: 1 }).lean();
 
     return NextResponse.json({
       categories: categories.map(transformCategory),
@@ -158,13 +158,17 @@ export async function POST(
       );
     }
 
-    // Determine order if not provided
+    // Determine order if not provided.
+    // If the sibling group has been manually ordered (any sibling has order >= 1),
+    // append to the end. Otherwise leave order at 0 so the group stays sorted
+    // alphabetically (A–Z) by default.
     let categoryOrder = order;
     if (categoryOrder === undefined) {
       const maxOrderCategory = await Category.findOne({ parentId: normalizedParentId })
         .sort({ order: -1 })
         .lean();
-      categoryOrder = maxOrderCategory ? maxOrderCategory.order + 1 : 0;
+      categoryOrder =
+        maxOrderCategory && maxOrderCategory.order >= 1 ? maxOrderCategory.order + 1 : 0;
     }
 
     // Create the category

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -11,7 +11,8 @@
  * - 5.1: Search the knowledgebase using keywords and natural language
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { CategoryTree } from '@/components/CategoryTree';
 import { EntryCard } from '@/components/EntryCard';
 import { SearchBar } from '@/components/SearchBar';
@@ -49,11 +50,67 @@ interface SearchResponse {
   mode: string;
 }
 
-export default function BrowsePage() {
+/**
+ * Collect a category's ID plus all of its descendants' IDs, so a parent category
+ * page rolls up entries from every nested sub-category. Returns just the id if
+ * the node isn't found yet (e.g. tree still loading).
+ */
+function collectCategoryAndDescendantIds(tree: CategoryTreeNode[], targetId: string): string[] {
+  const findNode = (nodes: CategoryTreeNode[]): CategoryTreeNode | null => {
+    for (const node of nodes) {
+      if (node._id === targetId) return node;
+      const found = findNode(node.children);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  const collect = (node: CategoryTreeNode): string[] => [
+    node._id,
+    ...node.children.flatMap(collect),
+  ];
+
+  const node = findNode(tree);
+  return node ? collect(node) : [targetId];
+}
+
+/** Find a category node by ID anywhere in the tree. */
+function findCategoryNode(tree: CategoryTreeNode[], targetId: string): CategoryTreeNode | null {
+  for (const node of tree) {
+    if (node._id === targetId) return node;
+    const found = findCategoryNode(node.children, targetId);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Flatten a category subtree into a depth-first ordered list (including the root
+ * node itself). `trail` holds the names of intermediate ancestors between the
+ * selected root and the node (excluding both), used as a breadcrumb hint so the
+ * grouped view can convey hierarchy without ragged indentation.
+ */
+function flattenSubtree(
+  node: CategoryTreeNode,
+  depth = 0,
+  trail: string[] = []
+): { node: CategoryTreeNode; depth: number; trail: string[] }[] {
+  const childTrail = depth === 0 ? [] : [...trail, node.name];
+  return [
+    { node, depth, trail },
+    ...node.children.flatMap((child) => flattenSubtree(child, depth + 1, childTrail)),
+  ];
+}
+
+function BrowsePageContent() {
   const { close } = useMobileNav();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // The selected category is driven by the `categoryId` URL param so that links
+  // (breadcrumbs, left nav) and browser back/forward stay in sync with the view.
+  const selectedCategoryId = searchParams.get('categoryId');
   const [tree, setTree] = useState<CategoryTreeNode[]>([]);
   const [entries, setEntries] = useState<Omit<IEntry, 'body'>[]>([]);
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [entriesLoading, setEntriesLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -107,19 +164,32 @@ export default function BrowsePage() {
     fetchTags();
   }, []);
 
+  // The currently selected category node, and whether to show the grouped-by-
+  // sub-category view (a parent with sub-categories) vs a flat paginated list.
+  const selectedNode = selectedCategoryId ? findCategoryNode(tree, selectedCategoryId) : null;
+  const isGroupedView = !!selectedNode && selectedNode.children.length > 0;
+
   // Fetch entries when category, page, or filters change
   const fetchEntries = useCallback(async () => {
     setEntriesLoading(true);
     try {
       const params = new URLSearchParams();
+      const node = selectedCategoryId ? findCategoryNode(tree, selectedCategoryId) : null;
+      const grouped = !!node && node.children.length > 0;
+
       if (selectedCategoryId) {
-        params.set('categoryId', selectedCategoryId);
+        // Roll up the selected category and all of its sub-categories.
+        collectCategoryAndDescendantIds(tree, selectedCategoryId).forEach((id) =>
+          params.append('categoryId', id)
+        );
       }
       // Add filter parameters
       selectedTags.forEach((tag) => params.append('tag', tag));
       selectedLanguages.forEach((language) => params.append('language', language));
-      params.set('page', page.toString());
-      params.set('limit', '20');
+      // Grouped view renders all entries organized by sub-category, so fetch them
+      // all in one page rather than paginating across group boundaries.
+      params.set('page', grouped ? '1' : page.toString());
+      params.set('limit', grouped ? '500' : '20');
 
       const res = await fetch(`/api/entries?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch entries');
@@ -132,15 +202,15 @@ export default function BrowsePage() {
     } finally {
       setEntriesLoading(false);
     }
-  }, [selectedCategoryId, page, selectedTags, selectedLanguages]);
+  }, [selectedCategoryId, page, selectedTags, selectedLanguages, tree]);
 
   useEffect(() => {
     fetchEntries();
   }, [fetchEntries]);
 
   const handleCategorySelect = (categoryId: string | null) => {
-    setSelectedCategoryId(categoryId);
-    setPage(1); // Reset to first page when category changes
+    // Update the URL param; the view derives its category from it.
+    router.push(categoryId ? `/browse?categoryId=${categoryId}` : '/browse');
     // Exit search mode when selecting a category
     setIsSearchMode(false);
     setSearchQuery('');
@@ -148,6 +218,12 @@ export default function BrowsePage() {
     setSearchError(null);
     close();
   };
+
+  // Reset to the first page whenever the selected category changes (covers both
+  // in-app selection and navigation via breadcrumb links / browser history).
+  useEffect(() => {
+    setPage(1);
+  }, [selectedCategoryId]);
 
   // Clear all filters
   const handleClearFilters = useCallback(() => {
@@ -333,6 +409,56 @@ export default function BrowsePage() {
                       No entries found in this category.
                     </p>
                   </div>
+                ) : isGroupedView && selectedNode ? (
+                  // Grouped view: entries organized by sub-category, mirroring the
+                  // left-nav hierarchy (depth-first, indented by depth).
+                  (() => {
+                    const entriesByCategory = new Map<string, typeof entries>();
+                    for (const entry of entries) {
+                      const list = entriesByCategory.get(entry.categoryId) ?? [];
+                      list.push(entry);
+                      entriesByCategory.set(entry.categoryId, list);
+                    }
+                    const sections = flattenSubtree(selectedNode).filter(
+                      ({ node }) => (entriesByCategory.get(node._id)?.length ?? 0) > 0
+                    );
+                    return (
+                      <div className="space-y-6">
+                        {sections.map(({ node, depth, trail }) => {
+                          const sectionEntries = entriesByCategory.get(node._id) ?? [];
+                          return (
+                            <section key={node._id}>
+                              {/* Skip a header for the selected category's own entries —
+                                  the page heading already names it. */}
+                              {depth > 0 && (
+                                <div className="mb-2 flex items-baseline gap-2 border-b border-[var(--color-border)] pb-1.5">
+                                  {trail.length > 0 && (
+                                    <span className="text-xs text-[var(--color-foreground-muted)]">
+                                      {trail.join(' / ')} /
+                                    </span>
+                                  )}
+                                  <button
+                                    onClick={() => handleCategorySelect(node._id)}
+                                    className="text-sm font-semibold text-[var(--color-foreground)] hover:text-[var(--color-primary)] cursor-pointer"
+                                  >
+                                    {node.name}
+                                  </button>
+                                  <span className="text-xs text-[var(--color-foreground-muted)]">
+                                    {sectionEntries.length}
+                                  </span>
+                                </div>
+                              )}
+                              <div className="space-y-1">
+                                {sectionEntries.map((entry) => (
+                                  <EntryCard key={entry._id} entry={entry} compact />
+                                ))}
+                              </div>
+                            </section>
+                          );
+                        })}
+                      </div>
+                    );
+                  })()
                 ) : (
                   <>
                     <div className="space-y-4">
@@ -388,5 +514,19 @@ export default function BrowsePage() {
           </div>
         </aside>
     </div>
+  );
+}
+
+export default function BrowsePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="animate-pulse text-[var(--color-foreground-muted)]">Loading...</div>
+        </div>
+      }
+    >
+      <BrowsePageContent />
+    </Suspense>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -263,6 +263,20 @@ a:not(.prose *) {
   cursor: pointer;
 }
 
+/**
+ * Cursor pointer for all buttons by default.
+ * Kept at element-selector specificity (0,0,1) so any explicit Tailwind cursor
+ * utility (e.g. cursor-grab on a drag handle, disabled:cursor-not-allowed)
+ * overrides it. Disabled buttons fall back to not-allowed.
+ */
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
 /* Code block styles using tokens */
 code {
   background-color: var(--color-code-background);

--- a/src/components/AIWritingPanel.tsx
+++ b/src/components/AIWritingPanel.tsx
@@ -15,13 +15,25 @@
 
 import { useState, useCallback } from 'react';
 import type { EntryFrontmatter } from '@/types/entry';
-import { Search, Sparkles, PenLine, Tags, Pin } from 'lucide-react';
+import { Search, Sparkles, PenLine, Tags, Pin, LayoutTemplate, Send } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 /**
  * Writing action types supported by the panel
  */
-type WritingAction = 'review' | 'improve' | 'expand' | 'suggest-tags' | 'suggest-title';
+type WritingAction =
+  | 'review'
+  | 'improve'
+  | 'expand'
+  | 'reformat'
+  | 'custom'
+  | 'suggest-tags'
+  | 'suggest-title';
+
+/** Actions whose output replaces the editor body (or selection) rather than being appended */
+function isReplaceAction(action: WritingAction): boolean {
+  return action === 'reformat' || action === 'custom';
+}
 
 /**
  * Artifact representing a single AI output
@@ -32,6 +44,8 @@ interface Artifact {
   content: string;
   timestamp: Date;
   isStreaming: boolean;
+  /** Whether applying this artifact replaces the body/selection (vs appends) */
+  replace: boolean;
 }
 
 /**
@@ -64,6 +78,12 @@ const ACTION_BUTTONS: ActionButton[] = [
     icon: PenLine,
   },
   {
+    action: 'reformat',
+    label: 'Reformat (DDS)',
+    description: 'Reformat the content using the docs-design-system component library',
+    icon: LayoutTemplate,
+  },
+  {
     action: 'suggest-tags',
     label: 'Suggest Tags',
     description: 'Suggest relevant tags for this content',
@@ -81,7 +101,7 @@ interface AIWritingPanelProps {
   body: string;
   frontmatter: EntryFrontmatter;
   selection?: string;
-  onApply: (content: string) => void;
+  onApply: (content: string, replace: boolean) => void;
 }
 
 export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWritingPanelProps) {
@@ -89,12 +109,13 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
   const [activeArtifactId, setActiveArtifactId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [customPrompt, setCustomPrompt] = useState('');
 
   /**
    * Execute a writing action and stream the response
    */
   const executeAction = useCallback(
-    async (action: WritingAction) => {
+    async (action: WritingAction, customPromptArg?: string) => {
       setError(null);
       setIsLoading(true);
 
@@ -106,6 +127,7 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
         content: '',
         timestamp: new Date(),
         isStreaming: true,
+        replace: isReplaceAction(action),
       };
 
       setArtifacts((prev) => [...prev, newArtifact]);
@@ -122,6 +144,7 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
             body,
             frontmatter,
             selection,
+            customPrompt: customPromptArg,
           }),
         });
 
@@ -206,9 +229,15 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
   const handleApply = useCallback(() => {
     const activeArtifact = artifacts.find((a) => a.id === activeArtifactId);
     if (activeArtifact && activeArtifact.content) {
-      onApply(activeArtifact.content);
+      onApply(activeArtifact.content, activeArtifact.replace);
     }
   }, [artifacts, activeArtifactId, onApply]);
+
+  const handleRunCustom = useCallback(() => {
+    const trimmed = customPrompt.trim();
+    if (!trimmed || isLoading) return;
+    executeAction('custom', trimmed);
+  }, [customPrompt, isLoading, executeAction]);
 
   /**
    * Close an artifact tab
@@ -229,6 +258,7 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
    * Get display label for an action
    */
   const getActionLabel = (action: WritingAction): string => {
+    if (action === 'custom') return 'Custom';
     return ACTION_BUTTONS.find((b) => b.action === action)?.label || action;
   };
 
@@ -271,6 +301,46 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
               <span>{button.label}</span>
             </button>
           ))}
+        </div>
+
+        {/* Custom prompt */}
+        <div className="mt-3">
+          <label
+            htmlFor="ai-custom-prompt"
+            className="block text-xs font-medium text-[var(--color-foreground-muted)] mb-1"
+          >
+            Custom instruction
+          </label>
+          <div className="flex items-end gap-2">
+            <textarea
+              id="ai-custom-prompt"
+              value={customPrompt}
+              onChange={(e) => setCustomPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault();
+                  handleRunCustom();
+                }
+              }}
+              rows={2}
+              placeholder={
+                selection
+                  ? 'Tell the AI how to rewrite the selected text…'
+                  : 'Tell the AI how to rewrite the entry (e.g. “turn the steps into a Steps component”)…'
+              }
+              disabled={isLoading}
+              className="flex-1 resize-y px-3 py-2 text-xs rounded-md bg-[var(--color-surface)] text-[var(--color-foreground)] border border-[var(--color-border)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] disabled:opacity-50"
+            />
+            <button
+              onClick={handleRunCustom}
+              disabled={isLoading || !customPrompt.trim()}
+              title="Run custom instruction (⌘/Ctrl+Enter)"
+              className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md bg-[var(--color-primary)] text-[var(--color-primary-foreground)] hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Send className="w-3.5 h-3.5" />
+              <span>Run</span>
+            </button>
+          </div>
         </div>
       </div>
 
@@ -340,7 +410,11 @@ export function AIWritingPanel({ body, frontmatter, selection, onApply }: AIWrit
             onClick={handleApply}
             className="w-full px-4 py-2 text-sm font-medium cursor-pointer bg-[var(--color-primary)] text-[var(--color-primary-foreground)] rounded-md hover:opacity-90 transition-opacity"
           >
-            Apply to Editor
+            {activeArtifact.replace
+              ? selection
+                ? 'Replace selection'
+                : 'Replace entry content'
+              : 'Apply to Editor'}
           </button>
         </div>
       )}

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -10,6 +10,23 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { CategoryTreeNode, ICategory } from '@/types/category';
 
 interface CreateCategoryRequest {
@@ -33,7 +50,7 @@ interface CategoryManagerProps {
   onCreateCategory: (data: CreateCategoryRequest) => Promise<ICategory>;
   onUpdateCategory: (id: string, data: UpdateCategoryRequest) => Promise<ICategory>;
   onDeleteCategory: (id: string) => Promise<void>;
-  onReorderCategories: (categoryId: string, newOrder: number) => Promise<void>;
+  onReorderCategories: (parentId: string | null, orderedIds: string[]) => Promise<void>;
   onRefresh: () => Promise<void>;
 }
 
@@ -76,6 +93,43 @@ function findNodeById(nodes: CategoryTreeNode[], id: string): CategoryTreeNode |
   return null;
 }
 
+/** Get the ordered sibling list (the array containing the node) for a given node ID */
+function getSiblings(nodes: CategoryTreeNode[], targetId: string): CategoryTreeNode[] | null {
+  if (nodes.some((n) => n._id === targetId)) return nodes;
+  for (const node of nodes) {
+    const found = getSiblings(node.children, targetId);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Order a list of nodes to match the given ID sequence (ignores unknown IDs) */
+function orderById(items: CategoryTreeNode[], orderedIds: string[]): CategoryTreeNode[] {
+  const map = new Map(items.map((item) => [item._id, item]));
+  return orderedIds
+    .map((id) => map.get(id))
+    .filter((node): node is CategoryTreeNode => Boolean(node));
+}
+
+/**
+ * Return a new tree with the children of `parentId` (or the root list when
+ * parentId is null) reordered to match `orderedIds`. Other branches are left intact.
+ */
+function reorderSiblings(
+  nodes: CategoryTreeNode[],
+  parentId: string | null,
+  orderedIds: string[]
+): CategoryTreeNode[] {
+  if (parentId === null) {
+    return orderById(nodes, orderedIds);
+  }
+  return nodes.map((node) =>
+    node._id === parentId
+      ? { ...node, children: orderById(node.children, orderedIds) }
+      : { ...node, children: reorderSiblings(node.children, parentId, orderedIds) }
+  );
+}
+
 /** Find the parent ID of a node in the tree */
 function findParentId(
   nodes: CategoryTreeNode[],
@@ -104,15 +158,11 @@ interface CategoryNodeProps {
   onStartDelete: (categoryId: string) => void;
   onConfirmDelete: (categoryId: string) => void;
   onCancelDelete: () => void;
-  onMoveUp: (categoryId: string, currentOrder: number) => void;
-  onMoveDown: (categoryId: string, currentOrder: number) => void;
   onStartMove: (categoryId: string) => void;
   onStartCreate: (parentId: string | null) => void;
   creatingParentId: string | null | undefined;
   onCancelCreate: () => void;
   onSubmitCreate: (name: string) => void;
-  isFirst: boolean;
-  isLast: boolean;
 }
 
 function CategoryNode({
@@ -129,21 +179,26 @@ function CategoryNode({
   onStartDelete,
   onConfirmDelete,
   onCancelDelete,
-  onMoveUp,
-  onMoveDown,
   onStartMove,
   onStartCreate,
   creatingParentId,
   onCancelCreate,
   onSubmitCreate,
-  isFirst,
-  isLast,
 }: CategoryNodeProps) {
   const hasChildren = node.children.length > 0;
   const isExpanded = expandedIds.has(node._id);
   const isEditing = editingId === node._id;
   const isDeleting = deletingId === node._id;
   const isCreatingChild = creatingParentId === node._id;
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: node._id,
+  });
+  const sortableStyle: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
 
   // Use node.name as initial value
   const [editName, setEditName] = useState(node.name);
@@ -193,11 +248,25 @@ function CategoryNode({
   };
 
   return (
-    <div>
+    <div ref={setNodeRef} style={sortableStyle}>
       <div
         className="group flex items-center gap-1 px-2 py-1.5 text-sm rounded-md hover:bg-[var(--color-surface-hover)] transition-colors"
         style={{ paddingLeft: `${level * 20 + 8}px` }}
       >
+        {/* Drag handle */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] cursor-grab active:cursor-grabbing opacity-0 group-hover:opacity-100 transition-opacity touch-none"
+          title="Drag to reorder"
+          aria-label={`Drag to reorder ${node.name}`}
+        >
+          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M7 4a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM7 10a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM7 16a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM16 4a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM16 10a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM16 16a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
+          </svg>
+        </button>
+
         {/* Expand/collapse toggle */}
         {hasChildren || isCreatingChild ? (
           <button
@@ -289,42 +358,6 @@ function CategoryNode({
 
             {/* Action buttons */}
             <div className="opacity-0 group-hover:opacity-100 flex items-center gap-0.5 transition-opacity">
-              {/* Move up */}
-              <button
-                type="button"
-                onClick={() => onMoveUp(node._id, node.order)}
-                disabled={isFirst}
-                className="p-1 text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-surface)] rounded disabled:opacity-30 disabled:cursor-not-allowed"
-                title="Move up"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 15l7-7 7 7"
-                  />
-                </svg>
-              </button>
-
-              {/* Move down */}
-              <button
-                type="button"
-                onClick={() => onMoveDown(node._id, node.order)}
-                disabled={isLast}
-                className="p-1 text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-surface)] rounded disabled:opacity-30 disabled:cursor-not-allowed"
-                title="Move down"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </button>
-
               {/* Add child */}
               <button
                 type="button"
@@ -405,33 +438,34 @@ function CategoryNode({
       {/* Children */}
       {(hasChildren || isCreatingChild) && isExpanded && (
         <div>
-          {node.children.map((child, index) => (
-            <CategoryNode
-              key={child._id}
-              node={child}
-              level={level + 1}
-              expandedIds={expandedIds}
-              editingId={editingId}
-              deletingId={deletingId}
-              movingId={movingId}
-              onToggle={onToggle}
-              onStartEdit={onStartEdit}
-              onCancelEdit={onCancelEdit}
-              onSubmitEdit={onSubmitEdit}
-              onStartDelete={onStartDelete}
-              onConfirmDelete={onConfirmDelete}
-              onCancelDelete={onCancelDelete}
-              onMoveUp={onMoveUp}
-              onMoveDown={onMoveDown}
-              onStartMove={onStartMove}
-              onStartCreate={onStartCreate}
-              creatingParentId={creatingParentId}
-              onCancelCreate={onCancelCreate}
-              onSubmitCreate={onSubmitCreate}
-              isFirst={index === 0}
-              isLast={index === node.children.length - 1}
-            />
-          ))}
+          <SortableContext
+            items={node.children.map((c) => c._id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {node.children.map((child) => (
+              <CategoryNode
+                key={child._id}
+                node={child}
+                level={level + 1}
+                expandedIds={expandedIds}
+                editingId={editingId}
+                deletingId={deletingId}
+                movingId={movingId}
+                onToggle={onToggle}
+                onStartEdit={onStartEdit}
+                onCancelEdit={onCancelEdit}
+                onSubmitEdit={onSubmitEdit}
+                onStartDelete={onStartDelete}
+                onConfirmDelete={onConfirmDelete}
+                onCancelDelete={onCancelDelete}
+                onStartMove={onStartMove}
+                onStartCreate={onStartCreate}
+                creatingParentId={creatingParentId}
+                onCancelCreate={onCancelCreate}
+                onSubmitCreate={onSubmitCreate}
+              />
+            ))}
+          </SortableContext>
           {isCreatingChild && (
             <InlineCreateForm
               level={level + 1}
@@ -538,6 +572,18 @@ export function CategoryManager({
   const [creatingParentId, setCreatingParentId] = useState<string | null | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
 
+  // Local copy of the tree so drag-and-drop reorders can be applied optimistically
+  // (no refetch / page reload). Kept in sync with the prop for other operations.
+  const [localTree, setLocalTree] = useState<CategoryTreeNode[]>(tree);
+  useEffect(() => {
+    setLocalTree(tree);
+  }, [tree]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
   const handleToggle = useCallback((categoryId: string) => {
     setExpandedIds((prev) => {
       const next = new Set(prev);
@@ -599,30 +645,41 @@ export function CategoryManager({
     setDeletingId(null);
   }, []);
 
-  const handleMoveUp = useCallback(
-    async (categoryId: string, currentOrder: number) => {
-      try {
-        setError(null);
-        await onReorderCategories(categoryId, currentOrder - 1);
-        await onRefresh();
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to reorder category');
-      }
-    },
-    [onReorderCategories, onRefresh]
-  );
+  // Reorder within a sibling group via drag-and-drop. Dragging across different
+  // parents is ignored here — reparenting is handled by the dedicated "move" control.
+  // The new order is applied optimistically and persisted by renumbering the whole
+  // sibling group (avoids duplicate/negative order values).
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
 
-  const handleMoveDown = useCallback(
-    async (categoryId: string, currentOrder: number) => {
-      try {
-        setError(null);
-        await onReorderCategories(categoryId, currentOrder + 1);
-        await onRefresh();
-      } catch (err) {
+      const activeId = String(active.id);
+      const overId = String(over.id);
+
+      const activeParent = findParentId(localTree, activeId) ?? null;
+      const overParent = findParentId(localTree, overId) ?? null;
+      if (activeParent !== overParent) return;
+
+      const siblings = getSiblings(localTree, activeId);
+      if (!siblings) return;
+      const ids = siblings.map((s) => s._id);
+      const oldIndex = ids.indexOf(activeId);
+      const newIndex = ids.indexOf(overId);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newOrderedIds = arrayMove(ids, oldIndex, newIndex);
+      const previousTree = localTree;
+
+      // Optimistic update, then persist; revert on failure.
+      setLocalTree(reorderSiblings(localTree, activeParent, newOrderedIds));
+      setError(null);
+      onReorderCategories(activeParent, newOrderedIds).catch((err) => {
         setError(err instanceof Error ? err.message : 'Failed to reorder category');
-      }
+        setLocalTree(previousTree);
+      });
     },
-    [onReorderCategories, onRefresh]
+    [localTree, onReorderCategories]
   );
 
   const handleStartCreate = useCallback((parentId: string | null) => {
@@ -672,10 +729,10 @@ export function CategoryManager({
       setDeletingId(null);
       setCreatingParentId(undefined);
       // Pre-select the current parent
-      const currentParentId = findParentId(tree, categoryId);
+      const currentParentId = findParentId(localTree, categoryId);
       setSelectedNewParentId(currentParentId ?? null);
     },
-    [movingId, tree]
+    [movingId, localTree]
   );
 
   const handleCancelMove = useCallback(() => {
@@ -687,7 +744,7 @@ export function CategoryManager({
     if (!movingId || selectedNewParentId === undefined) return;
 
     // Check if the parent is actually changing
-    const currentParentId = findParentId(tree, movingId);
+    const currentParentId = findParentId(localTree, movingId);
     if (selectedNewParentId === currentParentId) {
       setMovingId(null);
       setSelectedNewParentId(undefined);
@@ -706,23 +763,23 @@ export function CategoryManager({
     } finally {
       setIsMoving(false);
     }
-  }, [movingId, selectedNewParentId, tree, onUpdateCategory, onRefresh]);
+  }, [movingId, selectedNewParentId, localTree, onUpdateCategory, onRefresh]);
 
   // Compute valid parent options for the moving category
   const moveOptions = (() => {
     if (!movingId) return [];
-    const movingNode = findNodeById(tree, movingId);
+    const movingNode = findNodeById(localTree, movingId);
     if (!movingNode) return [];
     const excludedIds = collectDescendantIds(movingNode);
-    const flat = flattenTree(tree);
+    const flat = flattenTree(localTree);
     return flat.filter((c) => !excludedIds.has(c._id));
   })();
 
-  const movingNode = movingId ? findNodeById(tree, movingId) : null;
-  const currentParentIdOfMoving = movingId ? (findParentId(tree, movingId) ?? null) : null;
+  const movingNode = movingId ? findNodeById(localTree, movingId) : null;
+  const currentParentIdOfMoving = movingId ? (findParentId(localTree, movingId) ?? null) : null;
   const selectedParentName = (() => {
     if (selectedNewParentId === undefined || selectedNewParentId === null) return null;
-    const node = findNodeById(tree, selectedNewParentId);
+    const node = findNodeById(localTree, selectedNewParentId);
     return node?.name ?? null;
   })();
   const isParentChanged =
@@ -827,39 +884,42 @@ export function CategoryManager({
       )}
 
       <div className="space-y-0.5">
-        {tree.map((node, index) => (
-          <CategoryNode
-            key={node._id}
-            node={node}
-            level={0}
-            expandedIds={expandedIds}
-            editingId={editingId}
-            deletingId={deletingId}
-            movingId={movingId}
-            onToggle={handleToggle}
-            onStartEdit={handleStartEdit}
-            onCancelEdit={handleCancelEdit}
-            onSubmitEdit={handleSubmitEdit}
-            onStartDelete={handleStartDelete}
-            onConfirmDelete={handleConfirmDelete}
-            onCancelDelete={handleCancelDelete}
-            onMoveUp={handleMoveUp}
-            onMoveDown={handleMoveDown}
-            onStartMove={handleStartMove}
-            onStartCreate={handleStartCreate}
-            creatingParentId={creatingParentId}
-            onCancelCreate={handleCancelCreate}
-            onSubmitCreate={handleSubmitCreate}
-            isFirst={index === 0}
-            isLast={index === tree.length - 1}
-          />
-        ))}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={localTree.map((n) => n._id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {localTree.map((node) => (
+              <CategoryNode
+                key={node._id}
+                node={node}
+                level={0}
+                expandedIds={expandedIds}
+                editingId={editingId}
+                deletingId={deletingId}
+                movingId={movingId}
+                onToggle={handleToggle}
+                onStartEdit={handleStartEdit}
+                onCancelEdit={handleCancelEdit}
+                onSubmitEdit={handleSubmitEdit}
+                onStartDelete={handleStartDelete}
+                onConfirmDelete={handleConfirmDelete}
+                onCancelDelete={handleCancelDelete}
+                onStartMove={handleStartMove}
+                onStartCreate={handleStartCreate}
+                creatingParentId={creatingParentId}
+                onCancelCreate={handleCancelCreate}
+                onSubmitCreate={handleSubmitCreate}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
 
         {isCreatingAtRoot && (
           <InlineCreateForm level={0} onCancel={handleCancelCreate} onSubmit={handleSubmitCreate} />
         )}
 
-        {tree.length === 0 && !isCreatingAtRoot && (
+        {localTree.length === 0 && !isCreatingAtRoot && (
           <div className="py-8 text-center text-sm text-[var(--color-foreground-muted)]">
             No categories yet. Click &quot;Add Category&quot; to create your first one.
           </div>

--- a/src/components/CategoryNavSidebar.tsx
+++ b/src/components/CategoryNavSidebar.tsx
@@ -11,7 +11,8 @@ interface CategoryNavSidebarProps {
 
 /**
  * Wraps CategoryTree for use in server-component pages (e.g. entry detail).
- * Selecting any category navigates back to /browse.
+ * Selecting a category navigates to that category's browse page; selecting
+ * "All Entries" navigates to /browse with no category filter.
  */
 export function CategoryNavSidebar({ tree, selectedCategoryId }: CategoryNavSidebarProps) {
   const router = useRouter();
@@ -20,7 +21,9 @@ export function CategoryNavSidebar({ tree, selectedCategoryId }: CategoryNavSide
     <CategoryTree
       tree={tree}
       selectedCategoryId={selectedCategoryId}
-      onSelect={() => router.push('/browse')}
+      onSelect={(categoryId) =>
+        router.push(categoryId ? `/browse?categoryId=${categoryId}` : '/browse')
+      }
     />
   );
 }

--- a/src/components/CategoryTree.tsx
+++ b/src/components/CategoryTree.tsx
@@ -81,7 +81,7 @@ function CategoryNode({
         )}
         {!hasChildren && <span className="w-4" />}
         <span className="flex-1 truncate">{node.name}</span>
-        {node.entryCount > 0 && (
+        {node.totalEntryCount > 0 && (
           <span
             className={`
               text-xs px-1.5 py-0.5 rounded-full
@@ -92,7 +92,7 @@ function CategoryNode({
               }
             `}
           >
-            {node.entryCount}
+            {node.totalEntryCount}
           </span>
         )}
       </button>

--- a/src/components/EntryCard.tsx
+++ b/src/components/EntryCard.tsx
@@ -14,6 +14,8 @@ import type { IEntry } from '@/types/entry';
 
 interface EntryCardProps {
   entry: Omit<IEntry, 'body'>;
+  /** Render a dense single-row variant (used in grouped category listings) */
+  compact?: boolean;
 }
 
 const skillLevelLabels: Record<number, string> = {
@@ -32,8 +34,45 @@ const skillLevelColors: Record<number, string> = {
   5: 'bg-red-500/10 text-red-500',
 };
 
-export function EntryCard({ entry }: EntryCardProps) {
+const skillLevelDotColors: Record<number, string> = {
+  1: 'bg-green-500',
+  2: 'bg-blue-500',
+  3: 'bg-yellow-500',
+  4: 'bg-orange-500',
+  5: 'bg-red-500',
+};
+
+export function EntryCard({ entry, compact = false }: EntryCardProps) {
   const { frontmatter, slug, status } = entry;
+
+  if (compact) {
+    return (
+      <Link
+        href={`/browse/${slug}`}
+        className="flex items-center justify-between gap-3 px-3 py-2 rounded-md border border-transparent hover:border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors duration-150"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="truncate text-sm font-medium text-[var(--color-foreground)]">
+            {frontmatter.title}
+          </span>
+          {status === 'draft' && (
+            <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] rounded-full bg-[var(--color-warning-background)] text-[var(--color-warning)]">
+              Draft
+            </span>
+          )}
+          {frontmatter.isPrivate && (
+            <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] rounded-full bg-[var(--color-error-background)] text-[var(--color-error)]">
+              Private
+            </span>
+          )}
+        </div>
+        <span
+          className={`flex-shrink-0 w-2 h-2 rounded-full ${skillLevelDotColors[frontmatter.skillLevel]}`}
+          title={skillLevelLabels[frontmatter.skillLevel]}
+        />
+      </Link>
+    );
+  }
 
   return (
     <Link

--- a/src/components/EntryEditor.tsx
+++ b/src/components/EntryEditor.tsx
@@ -223,10 +223,15 @@ function EntryEditorInner({
   }, []);
 
   const handleApplyAIContent = useCallback(
-    (content: string) => {
+    (content: string, replace = false) => {
       if (selection) {
+        // Replace the selected text with the AI output (both append-style and
+        // replace-style actions operate on the selection when one is active).
         setBody((prev) => prev.replace(selection, content));
         setSelection(undefined);
+      } else if (replace) {
+        // Whole-body replacement (e.g. Reformat / Custom rewrite)
+        setBody(content);
       } else {
         setBody((prev) => prev + '\n\n' + content);
       }

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -4,14 +4,75 @@
  * MessageBubble Component
  *
  * Displays a single chat message with appropriate styling for user/assistant.
+ * Assistant messages are rendered as markdown (headings, lists, links, code, etc.);
+ * user messages are rendered as plain text.
  * Requirement 7.8: Chat UI components
  */
+
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface MessageBubbleProps {
   role: 'user' | 'assistant';
   content: string;
   isStreaming?: boolean;
 }
+
+/** Markdown element styling for assistant answers (readability-focused). */
+const markdownComponents: Components = {
+  h1: ({ children }) => <h1 className="text-lg font-semibold mt-3 mb-2 first:mt-0">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-base font-semibold mt-3 mb-2 first:mt-0">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h3>,
+  p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0 leading-relaxed">{children}</p>,
+  ul: ({ children }) => <ul className="my-2 ml-5 list-disc space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 ml-5 list-decimal space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-primary)] underline hover:no-underline"
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="my-2 border-l-2 border-[var(--color-border)] pl-3 text-[var(--color-foreground-muted)]">
+      {children}
+    </blockquote>
+  ),
+  code: ({ className, children }) => {
+    const isBlock = (className ?? '').includes('language-');
+    if (isBlock) {
+      return <code className={className}>{children}</code>;
+    }
+    return (
+      <code className="rounded bg-[var(--color-background)] px-1.5 py-0.5 text-[0.85em] font-mono">
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="my-2 overflow-x-auto rounded-md bg-[var(--color-background)] p-3 text-[0.85em] font-mono">
+      {children}
+    </pre>
+  ),
+  table: ({ children }) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="w-full border-collapse text-sm">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border border-[var(--color-border)] px-2 py-1 text-left font-semibold">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-[var(--color-border)] px-2 py-1">{children}</td>
+  ),
+  hr: () => <hr className="my-3 border-[var(--color-border)]" />,
+};
 
 export function MessageBubble({ role, content, isStreaming = false }: MessageBubbleProps) {
   const isUser = role === 'user';
@@ -25,10 +86,18 @@ export function MessageBubble({ role, content, isStreaming = false }: MessageBub
             : 'bg-[var(--color-surface)] text-[var(--color-foreground)] border border-[var(--color-border)]'
         }`}
       >
-        <div className="whitespace-pre-wrap break-words">
-          {content}
-          {isStreaming && <span className="inline-block w-2 h-4 ml-1 bg-current animate-pulse" />}
-        </div>
+        {isUser ? (
+          <div className="whitespace-pre-wrap break-words">{content}</div>
+        ) : (
+          <div className="break-words text-sm">
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+              {content}
+            </ReactMarkdown>
+            {isStreaming && (
+              <span className="inline-block w-2 h-4 ml-1 align-middle bg-current animate-pulse" />
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -7,7 +7,7 @@
  * Requirement 7.8: Chat UI components
  */
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 import { MessageBubble } from './MessageBubble';
 import { SourceCitations, type SourceCitation } from './SourceCitations';
 
@@ -24,11 +24,26 @@ interface MessageListProps {
 }
 
 export function MessageList({ messages, streamingContent, sources }: MessageListProps) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Whether the user is currently scrolled to (near) the bottom. We only
+  // auto-scroll on new content when this is true, so scrolling up to read
+  // previous messages is never interrupted by streaming updates.
+  const isAtBottomRef = useRef(true);
 
-  // Auto-scroll to bottom when new messages arrive
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    isAtBottomRef.current = distanceFromBottom < 80;
+  }, []);
+
+  // Auto-scroll the message container (not the page) when new content arrives,
+  // but only if the user was already at the bottom.
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const el = containerRef.current;
+    if (el && isAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
   }, [messages, streamingContent]);
 
   if (messages.length === 0 && !streamingContent) {
@@ -57,7 +72,7 @@ export function MessageList({ messages, streamingContent, sources }: MessageList
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 space-y-4">
+    <div ref={containerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto p-4 space-y-4">
       {messages.map((message) => (
         <MessageBubble key={message.id} role={message.role} content={message.content} />
       ))}
@@ -69,7 +84,6 @@ export function MessageList({ messages, streamingContent, sources }: MessageList
           <SourceCitations sources={sources} />
         </div>
       )}
-      <div ref={bottomRef} />
     </div>
   );
 }

--- a/src/components/mdx/MDXContent.tsx
+++ b/src/components/mdx/MDXContent.tsx
@@ -142,6 +142,7 @@ const components = {
   CollapserGroup,
   Column,
   Grid,
+  Heading,
   Link,
   List,
   ListItem,

--- a/src/lib/db/models/Category.ts
+++ b/src/lib/db/models/Category.ts
@@ -93,6 +93,7 @@ function buildTree(
       slug: cat.slug,
       order: cat.order,
       entryCount: entryCounts.get(id) || 0,
+      totalEntryCount: 0,
       children: [],
     });
   }
@@ -110,12 +111,20 @@ function buildTree(
     }
   }
 
-  // Sort children by order
+  // Sort children by explicit order, falling back to alphabetical (A–Z) by name
   const sortChildren = (nodes: CategoryTreeNode[]) => {
-    nodes.sort((a, b) => a.order - b.order);
+    nodes.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name));
     nodes.forEach((n) => sortChildren(n.children));
   };
   sortChildren(roots);
+
+  // Compute rollup counts (self + all descendants)
+  const computeTotals = (node: CategoryTreeNode): number => {
+    const childrenTotal = node.children.reduce((sum, child) => sum + computeTotals(child), 0);
+    node.totalEntryCount = node.entryCount + childrenTotal;
+    return node.totalEntryCount;
+  };
+  roots.forEach(computeTotals);
 
   return roots;
 }
@@ -124,7 +133,7 @@ function buildTree(
  * Static method to get full category tree
  */
 CategorySchema.statics.getTree = async function (): Promise<CategoryTreeNode[]> {
-  const categories = await this.find().sort({ order: 1 }).lean();
+  const categories = await this.find().sort({ order: 1, name: 1 }).lean();
   // Entry counts would be populated by a separate aggregation
   // For now, return tree without counts (counts added at query time)
   return buildTree(categories as CategoryDocument[]);

--- a/src/lib/db/queries/categories.ts
+++ b/src/lib/db/queries/categories.ts
@@ -45,6 +45,7 @@ export function buildTree(
       slug: cat.slug,
       order: cat.order,
       entryCount: entryCounts.get(id) || 0,
+      totalEntryCount: 0,
       children: [],
     });
   }
@@ -69,12 +70,23 @@ export function buildTree(
     }
   }
 
-  // Sort children by order recursively
+  // Sort children by explicit order, falling back to alphabetical (A–Z) by name.
+  // Categories with order 0 are "unordered" and sort alphabetically; once a sibling
+  // group is manually reordered, each member gets an explicit order >= 1.
   const sortChildren = (nodes: CategoryTreeNode[]) => {
-    nodes.sort((a, b) => a.order - b.order);
+    nodes.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name));
     nodes.forEach((n) => sortChildren(n.children));
   };
   sortChildren(roots);
+
+  // Compute rollup counts: each node's totalEntryCount is its own entries plus
+  // the totals of all descendants (post-order traversal).
+  const computeTotals = (node: CategoryTreeNode): number => {
+    const childrenTotal = node.children.reduce((sum, child) => sum + computeTotals(child), 0);
+    node.totalEntryCount = node.entryCount + childrenTotal;
+    return node.totalEntryCount;
+  };
+  roots.forEach(computeTotals);
 
   return roots;
 }
@@ -161,8 +173,8 @@ export async function getEntryCountForCategory(categoryId: string): Promise<numb
 export async function getCategoryTreeWithCounts(): Promise<CategoryTreeNode[]> {
   await connectToDatabase();
 
-  // Fetch all categories sorted by order
-  const categories = await Category.find().sort({ order: 1 }).lean();
+  // Fetch all categories sorted by order, then name (A–Z) as tiebreaker
+  const categories = await Category.find().sort({ order: 1, name: 1 }).lean();
 
   // Get entry counts
   const entryCounts = await getEntryCounts();

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -26,7 +26,10 @@ export interface CategoryTreeNode {
   name: string;
   slug: string;
   order: number;
+  /** Number of entries directly in this category */
   entryCount: number;
+  /** Number of entries in this category plus all descendants (rollup) */
+  totalEntryCount: number;
   children: CategoryTreeNode[];
 }
 


### PR DESCRIPTION
## Summary

A batch of UI/UX fixes and small features across chat, category management, browsing, and AI writing.

- **Chat** — assistant replies render as markdown (headings, lists, links, code, tables) via react-markdown + remark-gfm; user messages stay plain text. Auto-scroll is now scoped to the message container and only fires when the user is near the bottom, so scrolling up to read history isn't interrupted by streaming.
- **Categories** — replaced move up/down buttons with @dnd-kit drag-and-drop, persisted through a new `PUT /api/categories/reorder` route that renumbers the whole sibling group (1-based) to avoid duplicate/negative order values. Reorders apply optimistically and revert on failure. Unordered categories (order 0) sort alphabetically by default. Tree badges show a rollup count (self + all descendants) via the new `totalEntryCount` field.
- **Browse** — selected category is now driven by a `categoryId` URL param so breadcrumbs, left-nav, and back/forward stay in sync. Selecting a parent rolls up entries from all descendants and groups them by sub-category using a new compact `EntryCard` variant.
- **AI writing** — new "Reformat (DDS)" action that restructures an entry with the docs-design-system components, plus a free-form custom-instruction input. Both emit raw MDX and replace the body/selection rather than appending.
- **UI/MDX fixes** — default pointer cursor on all buttons (low specificity so Tailwind cursor utilities still win); registered `Heading` in the DDS MDX component map.

## Commits

- `chore(deps)` — add react-markdown and @dnd-kit
- `feat(chat)` — markdown rendering + contained auto-scroll
- `feat(categories)` — drag-and-drop reorder, alphabetical default, rollup counts
- `feat(browse)` — URL-driven category selection and grouped sub-category view
- `feat(ai-writing)` — reformat (DDS) and custom-prompt actions
- `fix(ui)` — default button cursor
- `fix(mdx)` — register Heading in the DDS component map

## Testing

No automated tests in this repo. Manual verification recommended for: category drag-and-drop + reorder persistence, browse grouped view, chat markdown rendering, and the new AI writing actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)