### PR TITLE
feat(files): add file attachments for embedding and download

### DIFF
--- a/src/app/admin/files/page.tsx
+++ b/src/app/admin/files/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ChevronDown, ChevronUp, FileText } from 'lucide-react';
+import { FileUploader } from '@/components/FileUploader';
+import { FileGallery } from '@/components/FileGallery';
+import { FileDetailPanel } from '@/components/FileDetailPanel';
+import type { IFileAttachment } from '@/types/file-attachment';
+
+export default function FilesPage() {
+  const router = useRouter();
+  const [authChecked, setAuthChecked] = useState(false);
+  const [uploaderOpen, setUploaderOpen] = useState(false);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [selectedFile, setSelectedFile] = useState<IFileAttachment | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/stats').then((res) => {
+      if (res.status === 401) {
+        router.push('/login');
+      } else {
+        setAuthChecked(true);
+      }
+    });
+  }, [router]);
+
+  if (!authChecked) {
+    return (
+      <div className="min-h-screen bg-[var(--color-background)]" />
+    );
+  }
+
+  function handleUploadComplete(file: IFileAttachment) {
+    setRefreshTrigger((t) => t + 1);
+    setUploaderOpen(false);
+    setSelectedFile(file);
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--color-background)' }}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '24px' }}>
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: '24px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <FileText size={22} style={{ color: 'var(--color-primary)' }} />
+            <div>
+              <h1 style={{ fontSize: '22px', fontWeight: 700, color: 'var(--color-foreground)', margin: 0 }}>
+                File Library
+              </h1>
+              <p style={{ fontSize: '13px', color: 'var(--color-foreground-muted)', marginTop: '2px' }}>
+                Upload and manage files for embedding or download in entries
+              </p>
+            </div>
+          </div>
+
+          <button
+            onClick={() => setUploaderOpen((o) => !o)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '8px 16px',
+              borderRadius: '6px',
+              border: 'none',
+              background: 'var(--color-primary)',
+              color: 'var(--color-primary-foreground)',
+              fontSize: '14px',
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            {uploaderOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+            {uploaderOpen ? 'Hide Uploader' : 'Upload File'}
+          </button>
+        </div>
+
+        {/* Collapsible uploader */}
+        {uploaderOpen && (
+          <div style={{ marginBottom: '24px' }}>
+            <FileUploader onUploadComplete={handleUploadComplete} />
+          </div>
+        )}
+
+        {/* Gallery */}
+        <FileGallery
+          refreshTrigger={refreshTrigger}
+          onSelectFile={setSelectedFile}
+        />
+      </div>
+
+      {/* Detail panel */}
+      <FileDetailPanel file={selectedFile} onClose={() => setSelectedFile(null)} />
+    </div>
+  );
+}

--- a/src/app/api/files/[id]/entries/route.ts
+++ b/src/app/api/files/[id]/entries/route.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /api/files/[id]/entries
+ * On-demand scan: find entries whose body contains this file's URL
+ * (authenticated)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { connectToDatabase } from '@/lib/db/connection';
+import { FileAttachment } from '@/lib/db/models/FileAttachment';
+import { Entry } from '@/lib/db/models/Entry';
+import { verifyToken, getAuthCookieName } from '@/lib/auth';
+
+async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(getAuthCookieName())?.value;
+  if (!token) return false;
+  const payload = await verifyToken(token);
+  return payload !== null;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    await connectToDatabase();
+
+    const file = await FileAttachment.findById(id).lean();
+    if (!file) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    const escapedUrl = file.url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const entries = await Entry.find({
+      body: { $regex: escapedUrl, $options: 'i' },
+    })
+      .select('slug frontmatter.title')
+      .lean();
+
+    return NextResponse.json({
+      entries: entries.map((e) => ({
+        _id: e._id.toString(),
+        slug: e.slug,
+        title: e.frontmatter.title,
+      })),
+    });
+  } catch (error) {
+    console.error('Error scanning entries for file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/files/[id]/route.ts
+++ b/src/app/api/files/[id]/route.ts
@@ -1,0 +1,201 @@
+/**
+ * Single file API routes
+ * GET /api/files/[id] - Get file metadata
+ * PATCH /api/files/[id] - Update description (authenticated)
+ * PUT /api/files/[id] - Replace file content, keeping same filename (authenticated)
+ * DELETE /api/files/[id] - Delete file from S3 + MongoDB (authenticated)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { connectToDatabase } from '@/lib/db/connection';
+import { FileAttachment } from '@/lib/db/models/FileAttachment';
+import { verifyToken, getAuthCookieName } from '@/lib/auth';
+import { deleteFromS3, uploadFileToS3 } from '@/lib/s3';
+import type { IFileAttachment } from '@/types/file-attachment';
+import type { FileAttachmentDocument } from '@/lib/db/models/FileAttachment';
+
+async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(getAuthCookieName())?.value;
+  if (!token) return false;
+  const payload = await verifyToken(token);
+  return payload !== null;
+}
+
+function transformFile(doc: FileAttachmentDocument): IFileAttachment {
+  return {
+    _id: doc._id.toString(),
+    filename: doc.filename,
+    s3Key: doc.s3Key,
+    url: doc.url,
+    description: doc.description,
+    sizeBytes: doc.sizeBytes,
+    mimeType: doc.mimeType,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}
+
+/**
+ * GET /api/files/[id]
+ * Get a single file's metadata
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    await connectToDatabase();
+
+    const file = await FileAttachment.findById(id).lean();
+    if (!file) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ file: transformFile(file) });
+  } catch (error) {
+    console.error('Error fetching file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/files/[id]
+ * Update description (authenticated)
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { description } = body as { description?: string };
+
+    if (typeof description !== 'string') {
+      return NextResponse.json({ error: 'description must be a string' }, { status: 400 });
+    }
+
+    await connectToDatabase();
+
+    const file = await FileAttachment.findByIdAndUpdate(
+      id,
+      { description: description.trim() },
+      { new: true }
+    ).lean();
+
+    if (!file) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ file: transformFile(file) });
+  } catch (error) {
+    console.error('Error updating file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/files/[id]
+ * Replace file content (must use same filename). Deletes old S3 object, uploads new one.
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    await connectToDatabase();
+
+    const existing = await FileAttachment.findById(id);
+    if (!existing) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    if (file.name !== existing.filename) {
+      return NextResponse.json(
+        { error: `Filename must match existing: "${existing.filename}"` },
+        { status: 400 }
+      );
+    }
+
+    const MAX_FILE_SIZE = 50 * 1024 * 1024;
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: 'File size must not exceed 50MB' }, { status: 400 });
+    }
+
+    // Delete old S3 object
+    await deleteFromS3(existing.s3Key);
+
+    // Upload new version
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { s3Key, url } = await uploadFileToS3(buffer, file.name, file.type);
+
+    existing.s3Key = s3Key;
+    existing.url = url;
+    existing.sizeBytes = file.size;
+    existing.mimeType = file.type;
+    await existing.save();
+
+    return NextResponse.json({ file: transformFile(existing.toObject()) });
+  } catch (error) {
+    console.error('Error replacing file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/files/[id]
+ * Delete from S3 then MongoDB (authenticated)
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { id } = await params;
+    await connectToDatabase();
+
+    const file = await FileAttachment.findById(id).lean();
+    if (!file) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    await deleteFromS3(file.s3Key);
+    await FileAttachment.findByIdAndDelete(id);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error deleting file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/files/[id]/route.ts
+++ b/src/app/api/files/[id]/route.ts
@@ -11,7 +11,7 @@ import { cookies } from 'next/headers';
 import { connectToDatabase } from '@/lib/db/connection';
 import { FileAttachment } from '@/lib/db/models/FileAttachment';
 import { verifyToken, getAuthCookieName } from '@/lib/auth';
-import { deleteFromS3, uploadFileToS3 } from '@/lib/s3';
+import { deleteFromS3, overwriteFileInS3 } from '@/lib/s3';
 import type { IFileAttachment } from '@/types/file-attachment';
 import type { FileAttachmentDocument } from '@/lib/db/models/FileAttachment';
 
@@ -148,15 +148,10 @@ export async function PUT(
       return NextResponse.json({ error: 'File size must not exceed 50MB' }, { status: 400 });
     }
 
-    // Delete old S3 object
-    await deleteFromS3(existing.s3Key);
-
-    // Upload new version
+    // Overwrite the same S3 key so the URL remains stable
     const buffer = Buffer.from(await file.arrayBuffer());
-    const { s3Key, url } = await uploadFileToS3(buffer, file.name, file.type);
+    await overwriteFileInS3(existing.s3Key, buffer, file.type);
 
-    existing.s3Key = s3Key;
-    existing.url = url;
     existing.sizeBytes = file.size;
     existing.mimeType = file.type;
     await existing.save();

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,129 @@
+/**
+ * Files API routes
+ * GET /api/files - List files with pagination and search
+ * POST /api/files - Upload a new file (authenticated only)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { connectToDatabase } from '@/lib/db/connection';
+import { FileAttachment } from '@/lib/db/models/FileAttachment';
+import { verifyToken, getAuthCookieName } from '@/lib/auth';
+import { uploadFileToS3 } from '@/lib/s3';
+import type { IFileAttachment } from '@/types/file-attachment';
+import type { FileAttachmentDocument } from '@/lib/db/models/FileAttachment';
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(getAuthCookieName())?.value;
+  if (!token) return false;
+  const payload = await verifyToken(token);
+  return payload !== null;
+}
+
+function transformFile(doc: FileAttachmentDocument): IFileAttachment {
+  return {
+    _id: doc._id.toString(),
+    filename: doc.filename,
+    s3Key: doc.s3Key,
+    url: doc.url,
+    description: doc.description,
+    sizeBytes: doc.sizeBytes,
+    mimeType: doc.mimeType,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+  };
+}
+
+/**
+ * GET /api/files
+ * List files with pagination and optional search
+ */
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    await connectToDatabase();
+
+    const searchParams = request.nextUrl.searchParams;
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)));
+    const search = searchParams.get('search');
+
+    const filter: Record<string, unknown> = {};
+    if (search && search.trim()) {
+      const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      filter.filename = { $regex: escaped, $options: 'i' };
+    }
+
+    const skip = (page - 1) * limit;
+    const [files, total] = await Promise.all([
+      FileAttachment.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+      FileAttachment.countDocuments(filter),
+    ]);
+
+    return NextResponse.json({
+      files: files.map(transformFile),
+      total,
+      page,
+      pages: Math.ceil(total / limit),
+    });
+  } catch (error) {
+    console.error('Error listing files:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/files
+ * Upload a new file
+ */
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse> {
+  const authed = await isAuthenticated();
+  if (!authed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: 'File size must not exceed 50MB' }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { s3Key, url } = await uploadFileToS3(buffer, file.name, file.type);
+
+    await connectToDatabase();
+
+    const fileAttachment = new FileAttachment({
+      filename: file.name,
+      s3Key,
+      url,
+      description: '',
+      sizeBytes: file.size,
+      mimeType: file.type,
+    });
+
+    await fileAttachment.save();
+
+    return NextResponse.json({ file: transformFile(fileAttachment.toObject()) }, { status: 201 });
+  } catch (error) {
+    console.error('Error uploading file:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/EntryEditor.tsx
+++ b/src/components/EntryEditor.tsx
@@ -17,9 +17,10 @@ import { MonacoPane } from './MonacoPane';
 import { PreviewPane } from './PreviewPane';
 import { AIWritingPanel } from './AIWritingPanel';
 import { ImagePickerPanel } from './ImagePickerPanel';
+import { FilePickerPanel } from './FilePickerPanel';
 import { CategorySelector } from './CategorySelector';
 import { useTheme } from './ThemeProvider';
-import { Pencil, Eye, ClipboardList, Images, Bot, Check, Loader2, Database } from 'lucide-react';
+import { Pencil, Eye, ClipboardList, Images, Bot, Check, Loader2, Database, Paperclip } from 'lucide-react';
 import { ErrorBoundary } from './ErrorBoundary';
 
 interface EntryEditorProps {
@@ -72,7 +73,7 @@ export function EntryEditor(props: EntryEditorProps) {
 }
 
 type LeftPanelView = 'editor' | 'preview';
-type RightPanelView = 'metadata' | 'images' | 'ai';
+type RightPanelView = 'metadata' | 'images' | 'files' | 'ai';
 
 function EntryEditorInner({
   entry,
@@ -382,6 +383,16 @@ function EntryEditorInner({
                 <Images className="w-4 h-4" /> Images
               </button>
               <button
+                onClick={() => setRightView('files')}
+                className={`px-3 py-1 text-sm font-medium rounded-md cursor-pointer transition-colors inline-flex items-center gap-1.5 ${
+                  rightView === 'files'
+                    ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
+                    : 'text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-surface-hover)]'
+                }`}
+              >
+                <Paperclip className="w-4 h-4" /> Files
+              </button>
+              <button
                 onClick={() => setRightView('ai')}
                 className={`px-3 py-1 text-sm font-medium rounded-md cursor-pointer transition-colors inline-flex items-center gap-1.5 ${
                   rightView === 'ai'
@@ -412,6 +423,8 @@ function EntryEditorInner({
               />
             ) : rightView === 'images' ? (
               <ImagePickerPanel />
+            ) : rightView === 'files' ? (
+              <FilePickerPanel />
             ) : (
               <AIWritingPanel
                 body={body}

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -1,0 +1,443 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { Copy, Pencil, ExternalLink, Trash2, Check, RefreshCw, FileText } from 'lucide-react';
+import type { IFileAttachment } from '@/types/file-attachment';
+import { formatBytes } from '@/lib/utils';
+
+interface FileCardProps {
+  file: IFileAttachment;
+  variant?: 'card' | 'row';
+  onDescriptionSaved: (file: IFileAttachment) => void;
+  onDeleted: (id: string) => void;
+  onReplaced?: (file: IFileAttachment) => void;
+  onSelect?: () => void;
+}
+
+export function FileCard({ file, variant = 'card', onDescriptionSaved, onDeleted, onReplaced, onSelect }: FileCardProps) {
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descValue, setDescValue] = useState(file.description);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [replacing, setReplacing] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const replaceInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleCopyUrl() {
+    await navigator.clipboard.writeText(file.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleSaveDesc() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/files/${file._id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: descValue }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        onDescriptionSaved(data.file);
+        setEditingDesc(false);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleReplace(e: React.ChangeEvent<HTMLInputElement>) {
+    const newFile = e.target.files?.[0];
+    if (!newFile) return;
+
+    if (newFile.name !== file.filename) {
+      alert(`Replacement file must have the same name: "${file.filename}"`);
+      if (replaceInputRef.current) replaceInputRef.current.value = '';
+      return;
+    }
+
+    setReplacing(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', newFile);
+
+      const res = await fetch(`/api/files/${file._id}`, { method: 'PUT', body: formData });
+      if (res.ok) {
+        const data = await res.json();
+        onReplaced?.(data.file);
+      }
+    } finally {
+      setReplacing(false);
+      if (replaceInputRef.current) replaceInputRef.current.value = '';
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Delete "${file.filename}"? This cannot be undone.`)) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/files/${file._id}`, { method: 'DELETE' });
+      if (res.ok) {
+        onDeleted(file._id);
+      }
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  function getFileExtension(): string {
+    const parts = file.filename.split('.');
+    if (parts.length <= 1) return '';
+    return (parts.pop() ?? '').toUpperCase();
+  }
+
+  const actions = (
+    <>
+      <button
+        onClick={handleCopyUrl}
+        title="Copy URL"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '6px',
+          borderRadius: '4px',
+          border: 'none',
+          background: copied ? 'var(--color-success-background, #d1fae5)' : 'transparent',
+          color: copied ? 'var(--color-success, #065f46)' : 'var(--color-foreground-secondary)',
+          cursor: 'pointer',
+        }}
+      >
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+      </button>
+
+      <button
+        onClick={() => { setEditingDesc(true); setDescValue(file.description); }}
+        title="Edit description"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '6px',
+          borderRadius: '4px',
+          border: 'none',
+          background: 'transparent',
+          color: 'var(--color-foreground-secondary)',
+          cursor: 'pointer',
+        }}
+      >
+        <Pencil size={14} />
+      </button>
+
+      <button
+        onClick={() => replaceInputRef.current?.click()}
+        disabled={replacing}
+        title="Replace file"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '6px',
+          borderRadius: '4px',
+          border: 'none',
+          background: 'transparent',
+          color: replacing ? 'var(--color-foreground-muted)' : 'var(--color-foreground-secondary)',
+          cursor: replacing ? 'not-allowed' : 'pointer',
+        }}
+      >
+        <RefreshCw size={14} />
+      </button>
+      <input
+        ref={replaceInputRef}
+        type="file"
+        style={{ display: 'none' }}
+        onChange={handleReplace}
+      />
+
+      <a
+        href={file.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Open in new tab"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '6px',
+          borderRadius: '4px',
+          color: 'var(--color-foreground-secondary)',
+          textDecoration: 'none',
+        }}
+      >
+        <ExternalLink size={14} />
+      </a>
+
+      <button
+        onClick={handleDelete}
+        disabled={deleting}
+        title="Delete"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '6px',
+          borderRadius: '4px',
+          border: 'none',
+          background: 'transparent',
+          color: deleting ? 'var(--color-foreground-muted)' : 'var(--color-error, #dc2626)',
+          cursor: deleting ? 'not-allowed' : 'pointer',
+        }}
+      >
+        <Trash2 size={14} />
+      </button>
+    </>
+  );
+
+  const descEditor = (
+    <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+      <input
+        value={descValue}
+        onChange={(e) => setDescValue(e.target.value)}
+        placeholder="Description"
+        style={{
+          flex: 1,
+          fontSize: '12px',
+          padding: '3px 6px',
+          border: '1px solid var(--color-border)',
+          borderRadius: '4px',
+          background: 'var(--color-background)',
+          color: 'var(--color-foreground)',
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSaveDesc();
+          if (e.key === 'Escape') { setEditingDesc(false); setDescValue(file.description); }
+        }}
+        autoFocus
+      />
+      <button
+        onClick={handleSaveDesc}
+        disabled={saving}
+        style={{
+          fontSize: '11px',
+          padding: '3px 8px',
+          borderRadius: '4px',
+          background: 'var(--color-primary)',
+          color: 'var(--color-primary-foreground)',
+          border: 'none',
+          cursor: saving ? 'not-allowed' : 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {saving ? '…' : 'Save'}
+      </button>
+      <button
+        onClick={() => { setEditingDesc(false); setDescValue(file.description); }}
+        style={{
+          fontSize: '11px',
+          padding: '3px 6px',
+          borderRadius: '4px',
+          background: 'transparent',
+          color: 'var(--color-foreground-secondary)',
+          border: '1px solid var(--color-border)',
+          cursor: 'pointer',
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+
+  // Row variant
+  if (variant === 'row') {
+    return (
+      <tr
+        style={{
+          borderBottom: '1px solid var(--color-border)',
+          background: 'var(--color-surface)',
+        }}
+      >
+        <td style={{ padding: '8px 12px', width: '56px' }}>
+          <div
+            onClick={onSelect}
+            style={{
+              width: '40px',
+              height: '40px',
+              borderRadius: '4px',
+              background: 'var(--color-background)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: onSelect ? 'pointer' : 'default',
+            }}
+          >
+            <FileText size={20} style={{ color: 'var(--color-foreground-muted)' }} />
+          </div>
+        </td>
+
+        <td style={{ padding: '8px 12px' }}>
+          {editingDesc ? (
+            descEditor
+          ) : (
+            <>
+              <p
+                style={{
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  color: 'var(--color-foreground)',
+                  margin: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  maxWidth: '320px',
+                }}
+                title={file.filename}
+              >
+                {file.filename}
+              </p>
+              {file.description && (
+                <p
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--color-foreground-muted)',
+                    margin: '2px 0 0',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '320px',
+                  }}
+                  title={file.description}
+                >
+                  {file.description}
+                </p>
+              )}
+            </>
+          )}
+        </td>
+
+        <td
+          style={{
+            padding: '8px 12px',
+            fontSize: '13px',
+            color: 'var(--color-foreground-secondary)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {getFileExtension()}
+        </td>
+
+        <td
+          style={{
+            padding: '8px 12px',
+            fontSize: '13px',
+            color: 'var(--color-foreground-secondary)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {formatBytes(file.sizeBytes)}
+        </td>
+
+        <td
+          style={{
+            padding: '8px 12px',
+            fontSize: '13px',
+            color: 'var(--color-foreground-secondary)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {new Date(file.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+        </td>
+
+        <td style={{ padding: '8px 8px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+            {actions}
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  // Card variant
+  return (
+    <div
+      style={{
+        border: '1px solid var(--color-border)',
+        borderRadius: '8px',
+        overflow: 'hidden',
+        background: 'var(--color-surface)',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          height: '120px',
+          background: 'var(--color-background)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: '4px',
+          overflow: 'hidden',
+          cursor: onSelect ? 'pointer' : 'default',
+        }}
+        onClick={onSelect}
+      >
+        <FileText size={32} style={{ color: 'var(--color-foreground-muted)' }} />
+        {getFileExtension() && (
+          <span style={{ fontSize: '11px', fontWeight: 600, color: 'var(--color-foreground-muted)' }}>
+            {getFileExtension()}
+          </span>
+        )}
+      </div>
+
+      <div style={{ padding: '12px', flex: 1, display: 'flex', flexDirection: 'column', gap: '6px' }}>
+        <p
+          style={{
+            fontSize: '13px',
+            fontWeight: 500,
+            color: 'var(--color-foreground)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={file.filename}
+        >
+          {file.filename}
+        </p>
+        <p style={{ fontSize: '12px', color: 'var(--color-foreground-muted)' }}>
+          {formatBytes(file.sizeBytes)}
+        </p>
+
+        {editingDesc ? (
+          descEditor
+        ) : (
+          <p
+            style={{
+              fontSize: '12px',
+              color: 'var(--color-foreground-secondary)',
+              fontStyle: file.description ? 'normal' : 'italic',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={file.description || 'No description'}
+          >
+            {file.description || 'No description'}
+          </p>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          borderTop: '1px solid var(--color-border)',
+          padding: '8px',
+          gap: '4px',
+        }}
+      >
+        {actions}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileDetailPanel.tsx
+++ b/src/components/FileDetailPanel.tsx
@@ -192,7 +192,7 @@ export function FileDetailPanel({ file, onClose }: FileDetailPanelProps) {
                     color: 'var(--color-foreground-secondary)',
                   }}
                 >
-                  {`<iframe src="${file.url}" width="100%" height="500" />`}
+                  {`<iframe src="${file.url}" width="100%" height="500" sandbox="allow-scripts" />`}
                 </code>
               </div>
             )}

--- a/src/components/FileDetailPanel.tsx
+++ b/src/components/FileDetailPanel.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X, ExternalLink, Download } from 'lucide-react';
+import Link from 'next/link';
+import type { IFileAttachment } from '@/types/file-attachment';
+import { formatBytes } from '@/lib/utils';
+
+interface ReferencingEntry {
+  _id: string;
+  slug: string;
+  title: string;
+}
+
+interface FileDetailPanelProps {
+  file: IFileAttachment | null;
+  onClose: () => void;
+}
+
+export function FileDetailPanel({ file, onClose }: FileDetailPanelProps) {
+  const [entries, setEntries] = useState<ReferencingEntry[]>([]);
+  const [loadingEntries, setLoadingEntries] = useState(false);
+  const [entriesError, setEntriesError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!file) return;
+
+    let cancelled = false;
+
+    async function fetchEntries() {
+      setLoadingEntries(true);
+      setEntriesError(null);
+      try {
+        const res = await fetch(`/api/files/${file!._id}/entries`);
+        const data = await res.json();
+        if (!cancelled) setEntries(data.entries || []);
+      } catch {
+        if (!cancelled) setEntriesError('Failed to load referencing entries');
+      } finally {
+        if (!cancelled) setLoadingEntries(false);
+      }
+    }
+
+    fetchEntries();
+    return () => { cancelled = true; };
+  }, [file]);
+
+  if (!file) return null;
+
+  const isEmbeddable = file.mimeType === 'text/html' || file.mimeType === 'application/pdf';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'flex-end',
+      }}
+    >
+      {/* Backdrop */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background: 'rgba(0,0,0,0.3)',
+        }}
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          maxWidth: '420px',
+          height: '100vh',
+          background: 'var(--color-surface)',
+          borderLeft: '1px solid var(--color-border)',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: '-4px 0 24px rgba(0,0,0,0.15)',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '16px',
+            borderBottom: '1px solid var(--color-border)',
+          }}
+        >
+          <h2 style={{ fontSize: '16px', fontWeight: 600, color: 'var(--color-foreground)', margin: 0 }}>
+            File Details
+          </h2>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '4px',
+              borderRadius: '4px',
+              border: 'none',
+              background: 'transparent',
+              color: 'var(--color-foreground-secondary)',
+              cursor: 'pointer',
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          {/* Metadata */}
+          <dl style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '6px 12px', margin: 0 }}>
+            <dt style={dtStyle}>Filename</dt>
+            <dd style={ddStyle}>{file.filename}</dd>
+
+            <dt style={dtStyle}>Description</dt>
+            <dd style={ddStyle}>{file.description || <em>None</em>}</dd>
+
+            <dt style={dtStyle}>Size</dt>
+            <dd style={ddStyle}>{formatBytes(file.sizeBytes)}</dd>
+
+            <dt style={dtStyle}>Type</dt>
+            <dd style={ddStyle}>{file.mimeType}</dd>
+
+            <dt style={dtStyle}>Uploaded</dt>
+            <dd style={ddStyle}>{new Date(file.createdAt).toLocaleDateString()}</dd>
+
+            <dt style={dtStyle}>Embeddable</dt>
+            <dd style={ddStyle}>{isEmbeddable ? 'Yes (iframe)' : 'No (download only)'}</dd>
+          </dl>
+
+          {/* Action links */}
+          <div style={{ display: 'flex', gap: '16px' }}>
+            <a
+              href={file.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '6px',
+                fontSize: '13px',
+                color: 'var(--color-primary)',
+                textDecoration: 'none',
+              }}
+            >
+              <ExternalLink size={14} />
+              Open in new tab
+            </a>
+            <a
+              href={file.url}
+              download={file.filename}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '6px',
+                fontSize: '13px',
+                color: 'var(--color-primary)',
+                textDecoration: 'none',
+              }}
+            >
+              <Download size={14} />
+              Download
+            </a>
+          </div>
+
+          {/* Usage snippets */}
+          <div>
+            <p style={{ fontSize: '12px', fontWeight: 600, color: 'var(--color-foreground-muted)', marginBottom: '8px' }}>
+              MDX Usage
+            </p>
+            {isEmbeddable && (
+              <div style={{ marginBottom: '8px' }}>
+                <p style={{ fontSize: '11px', color: 'var(--color-foreground-muted)', marginBottom: '4px' }}>
+                  Embed (iframe):
+                </p>
+                <code
+                  style={{
+                    display: 'block',
+                    fontSize: '11px',
+                    padding: '8px',
+                    background: 'var(--color-background)',
+                    borderRadius: '4px',
+                    wordBreak: 'break-all',
+                    color: 'var(--color-foreground-secondary)',
+                  }}
+                >
+                  {`<iframe src="${file.url}" width="100%" height="500" />`}
+                </code>
+              </div>
+            )}
+            <div>
+              <p style={{ fontSize: '11px', color: 'var(--color-foreground-muted)', marginBottom: '4px' }}>
+                Download link:
+              </p>
+              <code
+                style={{
+                  display: 'block',
+                  fontSize: '11px',
+                  padding: '8px',
+                  background: 'var(--color-background)',
+                  borderRadius: '4px',
+                  wordBreak: 'break-all',
+                  color: 'var(--color-foreground-secondary)',
+                }}
+              >
+                {`[${file.filename}](${file.url})`}
+              </code>
+            </div>
+          </div>
+
+          {/* URL */}
+          <div>
+            <p style={{ fontSize: '12px', color: 'var(--color-foreground-muted)', marginBottom: '4px' }}>
+              S3 URL
+            </p>
+            <code
+              style={{
+                display: 'block',
+                fontSize: '11px',
+                padding: '8px',
+                background: 'var(--color-background)',
+                borderRadius: '4px',
+                wordBreak: 'break-all',
+                color: 'var(--color-foreground-secondary)',
+              }}
+            >
+              {file.url}
+            </code>
+          </div>
+
+          {/* Referencing entries */}
+          <div>
+            <h3 style={{ fontSize: '14px', fontWeight: 600, color: 'var(--color-foreground)', marginBottom: '8px' }}>
+              Entries referencing this file
+            </h3>
+            {loadingEntries && (
+              <p style={{ fontSize: '13px', color: 'var(--color-foreground-muted)' }}>Scanning…</p>
+            )}
+            {entriesError && (
+              <p style={{ fontSize: '13px', color: 'var(--color-error, #dc2626)' }}>{entriesError}</p>
+            )}
+            {!loadingEntries && !entriesError && entries.length === 0 && (
+              <p style={{ fontSize: '13px', color: 'var(--color-foreground-muted)', fontStyle: 'italic' }}>
+                No entries reference this file.
+              </p>
+            )}
+            {!loadingEntries && entries.length > 0 && (
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                {entries.map((entry) => (
+                  <li key={entry._id}>
+                    <Link
+                      href={`/entries/${entry.slug}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        fontSize: '13px',
+                        color: 'var(--color-primary)',
+                        textDecoration: 'none',
+                      }}
+                    >
+                      {entry.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const dtStyle: React.CSSProperties = {
+  fontSize: '12px',
+  color: 'var(--color-foreground-muted)',
+  alignSelf: 'start',
+  paddingTop: '2px',
+};
+
+const ddStyle: React.CSSProperties = {
+  fontSize: '13px',
+  color: 'var(--color-foreground)',
+  margin: 0,
+  wordBreak: 'break-word',
+};

--- a/src/components/FileGallery.tsx
+++ b/src/components/FileGallery.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Search, LayoutGrid, List } from 'lucide-react';
+import { FileCard } from './FileCard';
+import type { IFileAttachment } from '@/types/file-attachment';
+
+interface FileGalleryProps {
+  refreshTrigger?: number;
+  onSelectFile?: (file: IFileAttachment) => void;
+}
+
+type ViewMode = 'grid' | 'list';
+
+export function FileGallery({ refreshTrigger, onSelectFile }: FileGalleryProps) {
+  const [files, setFiles] = useState<IFileAttachment[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<ViewMode>('list');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchFiles = useCallback(async (searchValue: string, pageNum: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ page: String(pageNum), limit: '20' });
+      if (searchValue.trim()) params.set('search', searchValue.trim());
+      const res = await fetch(`/api/files?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch files');
+      const data = await res.json();
+      setFiles(data.files);
+      setTotal(data.total);
+      setPages(data.pages);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error loading files');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPage(1);
+      fetchFiles(search, 1);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [search, fetchFiles]);
+
+  useEffect(() => {
+    fetchFiles(search, page);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, refreshTrigger]);
+
+  function handleDescriptionSaved(updated: IFileAttachment) {
+    setFiles((prev) => prev.map((f) => (f._id === updated._id ? updated : f)));
+  }
+
+  function handleDeleted(id: string) {
+    setFiles((prev) => prev.filter((f) => f._id !== id));
+    setTotal((prev) => prev - 1);
+  }
+
+  function handleReplaced(updated: IFileAttachment) {
+    setFiles((prev) => prev.map((f) => (f._id === updated._id ? updated : f)));
+  }
+
+  const viewToggleBtn = (mode: ViewMode, Icon: typeof LayoutGrid) => (
+    <button
+      onClick={() => setView(mode)}
+      title={mode === 'grid' ? 'Grid view' : 'List view'}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '7px',
+        borderRadius: '6px',
+        border: '1px solid var(--color-border)',
+        background: view === mode ? 'var(--color-surface-hover)' : 'var(--color-surface)',
+        color: view === mode ? 'var(--color-foreground)' : 'var(--color-foreground-secondary)',
+        cursor: 'pointer',
+      }}
+    >
+      <Icon size={16} />
+    </button>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      {/* Toolbar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <div style={{ position: 'relative', flex: '0 1 360px' }}>
+          <Search
+            size={16}
+            style={{
+              position: 'absolute',
+              left: '10px',
+              top: '50%',
+              transform: 'translateY(-50%)',
+              color: 'var(--color-foreground-muted)',
+              pointerEvents: 'none',
+            }}
+          />
+          <input
+            type="text"
+            placeholder="Search by filename…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{
+              width: '100%',
+              paddingLeft: '32px',
+              paddingRight: '12px',
+              paddingTop: '8px',
+              paddingBottom: '8px',
+              fontSize: '14px',
+              border: '1px solid var(--color-border)',
+              borderRadius: '6px',
+              background: 'var(--color-surface)',
+              color: 'var(--color-foreground)',
+            }}
+          />
+        </div>
+
+        <div style={{ flex: 1 }} />
+
+        <div style={{ display: 'flex', gap: '4px' }}>
+          {viewToggleBtn('grid', LayoutGrid)}
+          {viewToggleBtn('list', List)}
+        </div>
+      </div>
+
+      {/* Status */}
+      {!loading && !error && (
+        <p style={{ fontSize: '13px', color: 'var(--color-foreground-muted)' }}>
+          {total === 0 ? 'No files found.' : `${total} file${total !== 1 ? 's' : ''}`}
+        </p>
+      )}
+
+      {loading && (
+        <p style={{ fontSize: '13px', color: 'var(--color-foreground-muted)' }}>Loading…</p>
+      )}
+
+      {error && (
+        <p style={{ fontSize: '13px', color: 'var(--color-error, #dc2626)' }}>{error}</p>
+      )}
+
+      {/* Grid view */}
+      {!loading && files.length > 0 && view === 'grid' && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+            gap: '16px',
+          }}
+        >
+          {files.map((file) => (
+            <FileCard
+              key={file._id}
+              file={file}
+              onDescriptionSaved={handleDescriptionSaved}
+              onDeleted={handleDeleted}
+              onReplaced={handleReplaced}
+              onSelect={onSelectFile ? () => onSelectFile(file) : undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* List view */}
+      {!loading && files.length > 0 && view === 'list' && (
+        <div
+          style={{
+            border: '1px solid var(--color-border)',
+            borderRadius: '8px',
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: 'var(--color-background)' }}>
+                <th style={thStyle} />
+                <th style={{ ...thStyle, textAlign: 'left' }}>Filename</th>
+                <th style={{ ...thStyle, textAlign: 'left' }}>Type</th>
+                <th style={{ ...thStyle, textAlign: 'left' }}>Size</th>
+                <th style={{ ...thStyle, textAlign: 'left' }}>Created</th>
+                <th style={{ ...thStyle, textAlign: 'left' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {files.map((file) => (
+                <FileCard
+                  key={file._id}
+                  file={file}
+                  variant="row"
+                  onDescriptionSaved={handleDescriptionSaved}
+                  onDeleted={handleDeleted}
+                  onReplaced={handleReplaced}
+                  onSelect={onSelectFile ? () => onSelectFile(file) : undefined}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {pages > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            style={{
+              padding: '6px 12px',
+              fontSize: '13px',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              background: 'var(--color-surface)',
+              color: page <= 1 ? 'var(--color-foreground-muted)' : 'var(--color-foreground)',
+              cursor: page <= 1 ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Previous
+          </button>
+          <span style={{ fontSize: '13px', color: 'var(--color-foreground-secondary)' }}>
+            Page {page} of {pages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(pages, p + 1))}
+            disabled={page >= pages}
+            style={{
+              padding: '6px 12px',
+              fontSize: '13px',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              background: 'var(--color-surface)',
+              color: page >= pages ? 'var(--color-foreground-muted)' : 'var(--color-foreground)',
+              cursor: page >= pages ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const thStyle: React.CSSProperties = {
+  padding: '8px 12px',
+  fontSize: '11px',
+  fontWeight: 600,
+  color: 'var(--color-foreground-muted)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  borderBottom: '1px solid var(--color-border)',
+};

--- a/src/components/FilePickerPanel.tsx
+++ b/src/components/FilePickerPanel.tsx
@@ -98,7 +98,7 @@ export function FilePickerPanel() {
   async function handleCopyEmbed(file: IFileAttachment) {
     const isEmbeddable = file.mimeType === 'text/html' || file.mimeType === 'application/pdf';
     const snippet = isEmbeddable
-      ? `<iframe src="${file.url}" width="100%" height="500" />`
+      ? `<iframe src="${file.url}" width="100%" height="500" sandbox="allow-scripts" />`
       : `[${file.filename}](${file.url})`;
     await navigator.clipboard.writeText(snippet);
     setCopiedEmbed(file.url);

--- a/src/components/FilePickerPanel.tsx
+++ b/src/components/FilePickerPanel.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Upload, Search, Copy, FileText, Check, Code } from 'lucide-react';
+import type { IFileAttachment } from '@/types/file-attachment';
+import { formatBytes } from '@/lib/utils';
+
+const MAX_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function FilePickerPanel() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [lastUploaded, setLastUploaded] = useState<IFileAttachment | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [files, setFiles] = useState<IFileAttachment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const [copiedEmbed, setCopiedEmbed] = useState<string | null>(null);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploadError(null);
+
+    if (file.size > MAX_SIZE) {
+      setUploadError('File size must not exceed 50MB.');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch('/api/files', { method: 'POST', body: formData });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setUploadError(data.error || 'Upload failed.');
+        return;
+      }
+      const data = await res.json();
+      setLastUploaded(data.file);
+      if (inputRef.current) inputRef.current.value = '';
+    } catch {
+      setUploadError('Upload failed. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const fetchFiles = useCallback(async (searchValue: string) => {
+    if (!searchValue.trim()) {
+      setFiles([]);
+      return;
+    }
+
+    setLoading(true);
+    setSearchError(null);
+    try {
+      const params = new URLSearchParams({
+        search: searchValue.trim(),
+        limit: '5',
+      });
+      const res = await fetch(`/api/files?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to search files');
+      const data = await res.json();
+      setFiles(data.files);
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : 'Error searching files');
+      setFiles([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchFiles(search);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [search, fetchFiles]);
+
+  async function handleCopyUrl(url: string) {
+    await navigator.clipboard.writeText(url);
+    setCopiedUrl(url);
+    setTimeout(() => setCopiedUrl(null), 2000);
+  }
+
+  async function handleCopyEmbed(file: IFileAttachment) {
+    const isEmbeddable = file.mimeType === 'text/html' || file.mimeType === 'application/pdf';
+    const snippet = isEmbeddable
+      ? `<iframe src="${file.url}" width="100%" height="500" />`
+      : `[${file.filename}](${file.url})`;
+    await navigator.clipboard.writeText(snippet);
+    setCopiedEmbed(file.url);
+    setTimeout(() => setCopiedEmbed(null), 2000);
+  }
+
+  return (
+    <div className="p-4 space-y-4 h-full flex flex-col">
+      {/* Upload Section */}
+      <div>
+        <h3 className="text-sm font-medium text-[var(--color-foreground)] mb-2">Upload File</h3>
+        <button
+          onClick={() => inputRef.current?.click()}
+          disabled={uploading}
+          className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm border border-[var(--color-border)] rounded-md hover:bg-[var(--color-surface-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Upload className="w-4 h-4" />
+          {uploading ? 'Uploading...' : 'Choose File'}
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          onChange={handleFileChange}
+          disabled={uploading}
+        />
+        {uploadError && (
+          <p className="text-xs text-[var(--color-error)] mt-1">{uploadError}</p>
+        )}
+
+        {lastUploaded && (
+          <div className="mt-3 p-2 border border-[var(--color-border)] rounded-md bg-[var(--color-surface)]">
+            <div className="flex items-start gap-2">
+              <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded border bg-[var(--color-background)]">
+                <FileText className="w-6 h-6 text-[var(--color-foreground-muted)]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium text-[var(--color-foreground)] truncate">
+                  {lastUploaded.filename}
+                </p>
+                <p className="text-xs text-[var(--color-foreground-muted)] truncate font-mono bg-[var(--color-background)] px-1 rounded mt-1">
+                  {lastUploaded.url}
+                </p>
+                <div className="flex gap-1 mt-2">
+                  <button
+                    onClick={() => handleCopyUrl(lastUploaded.url)}
+                    className="flex items-center gap-1 px-2 py-1 text-xs bg-[var(--color-primary)] text-[var(--color-primary-foreground)] rounded hover:opacity-90"
+                  >
+                    {copiedUrl === lastUploaded.url ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                    URL
+                  </button>
+                  <button
+                    onClick={() => handleCopyEmbed(lastUploaded)}
+                    className="flex items-center gap-1 px-2 py-1 text-xs border border-[var(--color-border)] rounded hover:bg-[var(--color-surface-hover)]"
+                  >
+                    {copiedEmbed === lastUploaded.url ? <Check className="w-3 h-3" /> : <Code className="w-3 h-3" />}
+                    Snippet
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Search Section */}
+      <div className="flex-1 flex flex-col min-h-0">
+        <h3 className="text-sm font-medium text-[var(--color-foreground)] mb-2">Find Existing Files</h3>
+
+        <div className="relative mb-3">
+          <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 w-4 h-4 text-[var(--color-foreground-muted)]" />
+          <input
+            type="text"
+            placeholder="Search by filename..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-8 pr-3 py-2 text-sm bg-[var(--color-background)] border border-[var(--color-border)] rounded-md focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]"
+          />
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {loading && (
+            <p className="text-xs text-[var(--color-foreground-muted)]">Searching...</p>
+          )}
+
+          {searchError && (
+            <p className="text-xs text-[var(--color-error)]">{searchError}</p>
+          )}
+
+          {!loading && !searchError && search.trim() && files.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <FileText className="w-8 h-8 text-[var(--color-foreground-muted)] mb-2" />
+              <p className="text-xs text-[var(--color-foreground-muted)]">No files found</p>
+            </div>
+          )}
+
+          {!loading && files.length > 0 && (
+            <div className="space-y-2">
+              {files.map((file) => (
+                <div
+                  key={file._id}
+                  className="flex items-start gap-2 p-2 border border-[var(--color-border)] rounded-md bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)]"
+                >
+                  <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded border bg-[var(--color-background)]">
+                    <FileText className="w-6 h-6 text-[var(--color-foreground-muted)]" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium text-[var(--color-foreground)] truncate">
+                      {file.filename}
+                    </p>
+                    <p className="text-xs text-[var(--color-foreground-muted)]">
+                      {formatBytes(file.sizeBytes)} · {file.mimeType}
+                    </p>
+                    <div className="flex gap-1 mt-2">
+                      <button
+                        onClick={() => handleCopyUrl(file.url)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs bg-[var(--color-primary)] text-[var(--color-primary-foreground)] rounded hover:opacity-90"
+                      >
+                        {copiedUrl === file.url ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                        URL
+                      </button>
+                      <button
+                        onClick={() => handleCopyEmbed(file)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs border border-[var(--color-border)] rounded hover:bg-[var(--color-surface-hover)]"
+                      >
+                        {copiedEmbed === file.url ? <Check className="w-3 h-3" /> : <Code className="w-3 h-3" />}
+                        Snippet
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Upload } from 'lucide-react';
+import type { IFileAttachment } from '@/types/file-attachment';
+
+const MAX_SIZE = 50 * 1024 * 1024; // 50MB
+
+interface FileUploaderProps {
+  onUploadComplete: (file: IFileAttachment) => void;
+}
+
+export function FileUploader({ onUploadComplete }: FileUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+
+    if (file.size > MAX_SIZE) {
+      setError('File size must not exceed 50MB.');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch('/api/files', { method: 'POST', body: formData });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Upload failed.');
+        return;
+      }
+      const data = await res.json();
+      onUploadComplete(data.file);
+      if (inputRef.current) inputRef.current.value = '';
+    } catch {
+      setError('Upload failed. Please try again.');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          border: '2px dashed var(--color-border)',
+          borderRadius: '8px',
+          padding: '24px',
+          textAlign: 'center',
+          background: 'var(--color-surface)',
+        }}
+      >
+        <Upload
+          size={24}
+          style={{ margin: '0 auto 8px', color: 'var(--color-foreground-muted)' }}
+        />
+        <p style={{ fontSize: '14px', color: 'var(--color-foreground-secondary)', marginBottom: '12px' }}>
+          {uploading ? 'Uploading…' : 'Select a file to upload (max 50MB)'}
+        </p>
+        <label
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '8px 16px',
+            borderRadius: '6px',
+            background: 'var(--color-primary)',
+            color: 'var(--color-primary-foreground)',
+            fontSize: '14px',
+            fontWeight: 500,
+            cursor: uploading ? 'not-allowed' : 'pointer',
+            opacity: uploading ? 0.6 : 1,
+          }}
+        >
+          <Upload size={14} />
+          {uploading ? 'Uploading…' : 'Choose File'}
+          <input
+            ref={inputRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+            disabled={uploading}
+          />
+        </label>
+      </div>
+      {error && (
+        <p
+          style={{
+            marginTop: '8px',
+            fontSize: '13px',
+            color: 'var(--color-error, #dc2626)',
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -117,6 +117,9 @@ export function TopNav({ className = '' }: TopNavProps) {
                   <Link href="/admin/images" className={linkClasses('/admin/images')}>
                     Images
                   </Link>
+                  <Link href="/admin/files" className={linkClasses('/admin/files')}>
+                    Files
+                  </Link>
                   <Link href="/admin" className={linkClasses('/admin')}>
                     Admin
                   </Link>
@@ -183,6 +186,13 @@ export function TopNav({ className = '' }: TopNavProps) {
                       onClick={() => setDropdownOpen(false)}
                     >
                       Images
+                    </Link>
+                    <Link
+                      href="/admin/files"
+                      className={`block px-4 py-2 text-sm ${linkClasses('/admin/files')}`}
+                      onClick={() => setDropdownOpen(false)}
+                    >
+                      Files
                     </Link>
                     <Link
                       href="/admin"

--- a/src/lib/db/models/FileAttachment.ts
+++ b/src/lib/db/models/FileAttachment.ts
@@ -1,0 +1,57 @@
+import mongoose, { Schema, Model, Types } from 'mongoose';
+
+export interface FileAttachmentDocument {
+  _id: Types.ObjectId;
+  filename: string;
+  s3Key: string;
+  url: string;
+  description: string;
+  sizeBytes: number;
+  mimeType: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FileAttachmentSchema = new Schema<FileAttachmentDocument>(
+  {
+    filename: {
+      type: String,
+      required: [true, 'Filename is required'],
+      trim: true,
+    },
+    s3Key: {
+      type: String,
+      required: [true, 'S3 key is required'],
+      unique: true,
+      index: true,
+    },
+    url: {
+      type: String,
+      required: [true, 'URL is required'],
+    },
+    description: {
+      type: String,
+      default: '',
+      trim: true,
+    },
+    sizeBytes: {
+      type: Number,
+      required: [true, 'File size is required'],
+    },
+    mimeType: {
+      type: String,
+      required: [true, 'MIME type is required'],
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+FileAttachmentSchema.index({ createdAt: -1 });
+
+export const FileAttachment: Model<FileAttachmentDocument> =
+  (mongoose.models.FileAttachment as Model<FileAttachmentDocument>) ||
+  mongoose.model<FileAttachmentDocument>('FileAttachment', FileAttachmentSchema);
+
+export default FileAttachment;

--- a/src/lib/s3/helpers.ts
+++ b/src/lib/s3/helpers.ts
@@ -29,6 +29,30 @@ export async function uploadToS3(
   return { s3Key, url };
 }
 
+export async function uploadFileToS3(
+  buffer: Buffer,
+  filename: string,
+  mimeType: string
+): Promise<{ s3Key: string; url: string }> {
+  const sanitized = sanitizeFilename(filename);
+  const s3Key = `files/${randomUUID()}-${sanitized}`;
+  const bucket = getS3BucketName();
+  const region = process.env.AWS_REGION || 'us-east-1';
+
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: s3Key,
+      Body: buffer,
+      ContentType: mimeType,
+      ContentDisposition: `inline; filename="${filename}"`,
+    })
+  );
+
+  const url = getS3PublicUrl(bucket, region, s3Key);
+  return { s3Key, url };
+}
+
 export async function deleteFromS3(s3Key: string): Promise<void> {
   try {
     await getS3Client().send(

--- a/src/lib/s3/helpers.ts
+++ b/src/lib/s3/helpers.ts
@@ -45,12 +45,28 @@ export async function uploadFileToS3(
       Key: s3Key,
       Body: buffer,
       ContentType: mimeType,
-      ContentDisposition: `inline; filename="${filename}"`,
+      ContentDisposition: `inline; filename="${sanitized}"`,
     })
   );
 
   const url = getS3PublicUrl(bucket, region, s3Key);
   return { s3Key, url };
+}
+
+export async function overwriteFileInS3(
+  s3Key: string,
+  buffer: Buffer,
+  mimeType: string
+): Promise<void> {
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: getS3BucketName(),
+      Key: s3Key,
+      Body: buffer,
+      ContentType: mimeType,
+      ContentDisposition: `inline`,
+    })
+  );
 }
 
 export async function deleteFromS3(s3Key: string): Promise<void> {

--- a/src/lib/s3/index.ts
+++ b/src/lib/s3/index.ts
@@ -1,2 +1,2 @@
 export { getS3Client, getS3BucketName, getS3PublicUrl, isS3Configured } from './client';
-export { uploadToS3, deleteFromS3 } from './helpers';
+export { uploadToS3, uploadFileToS3, deleteFromS3 } from './helpers';

--- a/src/lib/s3/index.ts
+++ b/src/lib/s3/index.ts
@@ -1,2 +1,2 @@
 export { getS3Client, getS3BucketName, getS3PublicUrl, isS3Configured } from './client';
-export { uploadToS3, uploadFileToS3, deleteFromS3 } from './helpers';
+export { uploadToS3, uploadFileToS3, overwriteFileInS3, deleteFromS3 } from './helpers';

--- a/src/types/file-attachment.ts
+++ b/src/types/file-attachment.ts
@@ -1,0 +1,24 @@
+export interface IFileAttachment {
+  _id: string;
+  filename: string;
+  s3Key: string;
+  url: string;
+  description: string;
+  sizeBytes: number;
+  mimeType: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateFileAttachmentInput {
+  filename: string;
+  s3Key: string;
+  url: string;
+  description: string;
+  sizeBytes: number;
+  mimeType: string;
+}
+
+export interface UpdateFileAttachmentInput {
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- Adds file attachment system (upload, search, replace, delete) stored in S3 under `files/` prefix with MongoDB metadata
- Dedicated `/admin/files` management page with grid/list view, search, detail panel with MDX usage snippets (iframe embed vs download link)
- File picker panel integrated into entry editor (new "Files" tab alongside Images)
- File replacement enforces same-filename constraint so existing URLs remain valid
- 50MB max file size; any file type accepted

## Test plan
- [ ] Upload a file from the admin Files page — verify it appears in the gallery and S3
- [ ] Search by filename — verify filtering works
- [ ] Replace a file (same filename) — verify new content served at same URL
- [ ] Delete a file — verify removed from S3 and gallery
- [ ] Open detail panel — verify metadata, MDX snippets, and referencing entries
- [ ] In entry editor, switch to Files tab — verify upload and search work from picker
- [ ] Verify nav links appear on desktop and mobile